### PR TITLE
fixed text color on hover with context-panel items

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -254,6 +254,11 @@
   border-right: #333 2px solid !important;
  }
 
+ /* Context pane highlight item */
+ .context-pane .selector-item:hover a{
+  color: #444 !important;
+ }
+
  /* orange border left */
  .pagehead ul.tabs li a.selected,div.listing.navigation-focus,div.issues.navigation-focus {
   -moz-border-radius:0 !important;


### PR DESCRIPTION
context pane color item shows up as blue and highlight is blue. This fixes it.
