### PR TITLE
replace domain() with regexp()

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1,6 +1,6 @@
 @namespace url(http://www.w3.org/1999/xhtml);
 
-@-moz-document domain("github.com") {
+@-moz-document regexp("https?://(www\\.)?github.com/") {
 
 /* Github Dark Theme v1.2.24 (2/3/2012)
  * https://github.com/Mottie/Github-Dark


### PR DESCRIPTION
domain("github.com") applies also to a lot of user generated content, for example:

http://keplerproject.github.com/orbit/

replacing with regexp("https?://(www\.)?github.com/") prevents this.
