### PR TITLE
Reduce top and bottom padding in the code editor

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -150,6 +150,15 @@
  .linkable-line-number {
   border-right: #555 1px solid !important;
  }
+ /* code editor padding - code */
+ .file-code-line .blob-line-code .highlight {
+  padding-bottom: 0px !important;
+  padding-top: 0px !important;
+ }
+ /* code editor padding - line numbers */
+ .file-code-line .blob-line-nums {
+  padding: 0px !important;
+ }
  /* ace (gist editor) */
  .ace_cursor {
   border-left-color: #ddd !important;
@@ -452,7 +461,7 @@
  #contributions-calendar .contrib-details div,.mini-icon-remove-close:hover {
   color: #777 !important;
  }
- 
+
  /* darkest text; Context pane highlight item */
  .context-pane .selector-item:hover a,.mega-icon:before,.repo-label span,#notification-center li.unread a,
  .mini-icon-public-repo:before,.mini-icon-pull-request,.mini-icon-remove-close,.mini-icon-link,.mega-octicon:before {
@@ -800,7 +809,7 @@
   background: #300 !important;
   border-color: #500 !important;
   color: #ccc !important;
- }  
+ }
  /* git diff inline deletions (red) */
  .highlight .gd .x {
   background: #200 !important;


### PR DESCRIPTION
I noticed that there's a 5px top and bottom padding on Github's default style in the code editor and got rid of it.
