### PR TITLE
adding private repo color (was too contrasty before)

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -123,6 +123,11 @@
   font-size: 12px !important;
  }
 
+ /* === Private repos === */
+ .private .repo-list-item {
+  background-color: #3C3C3C !important;
+ }
+
  /* === Darken border === */
  pre,code,ul li,table,table tr,table td,h1,h2,h3,hr,img,#browser table,#browser table th,#issues .menu ul li,.counter,.issues td,
  ul.main_nav li.selected,.browser_header,.issue-head,.bootcamp-help .image,.clone-url-button,#wiki-wrapper h2,


### PR DESCRIPTION
github defaulted to "#fcf8e9" which is way too bright for this Dark theme
