### PR TITLE
removing color from octicons. This restores the color for octicons.

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -691,7 +691,7 @@
   /* shade darker */
   option, .news blockquote, .news blockquote p, #contributions-calendar .contrib-details div .num, .collection-stat,
   .flash-global a, #contributions-calendar .contrib-details div .lbl, .tag-info a, .authorship, a.browse-button,
-  .ghead .dir, .octicon, .repository-lang-stats .percent, .diffstat-summary, .diff-expander .octicon-unfold {
+  .ghead .dir, .repository-lang-stats .percent, .diffstat-summary, .diff-expander .octicon-unfold {
     color: #999 !important;
   }
   /* content text */


### PR DESCRIPTION
since `.octicon` DOES span quite a bit of elements - feel free to remove this, but it does look **much** better with those colors back in :)
