### PR TITLE
Made the commit status icons background transparent

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -180,7 +180,7 @@
   #network .repo span, .previewable-comment-form, .keyboard-mappings th, .api #header-wrapper .nav,
   .marketing-nav a.selected, #graph_data .tabs, .org-nav-item.selected, .edit-team-member:hover, tr.commit,
   .release-timeline .js-details-container, .section-heading-title a.js-selected-navigation-item, .featured-callout .screenshot,
-  .ace-github, .sidebar-module ul ul li a:hover, .sidebar-module h3 a:hover {
+  .ace-github, .sidebar-module ul ul li a:hover, .sidebar-module h3 a:hover, .timeline-commits .commit-meta .octicon {
     background: transparent !important;
   }
   .select-menu-item .octicon {


### PR DESCRIPTION
Previously the merged-build status-pending icon had a orange box background.
