### PR TITLE
Made the commit status icons background transparent... again!

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -185,7 +185,8 @@
   #network .repo span, .previewable-comment-form, .keyboard-mappings th, .api #header-wrapper .nav,
   .marketing-nav a.selected, #graph_data .tabs, .org-nav-item.selected, .edit-team-member:hover, tr.commit,
   .release-timeline .js-details-container, .section-heading-title a.js-selected-navigation-item, .featured-callout .screenshot,
-  .ace-github, .sidebar-module ul ul li a:hover, .sidebar-module h3 a:hover, .timeline-commits .commit-meta .octicon,
+  .ace-github, .sidebar-module ul ul li a:hover, .sidebar-module h3 a:hover,
+  .timeline-commits .commit-meta .status, .timeline-commits .commit-meta .octicon,
   .file .meta-divider {
     background: transparent !important;
   }


### PR DESCRIPTION
Github keeps changing their styles up.
