### PR TITLE
Icons: Add red color to octicon-x

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -980,7 +980,7 @@
   a.danger, .minibutton.danger, .button.danger, .minibutton.danger span, .closed.mini-icon, .closed.mega-octicon, .deletions,
   .closed.mega-octicon:before, .closed.octicon, .cdel, .gd .diff-line-num, .status-failure, .authors-and-code .deletions,
   .range-editor .range .range-action.octicon:hover, span.diffstat .diffstat-bar.diff-deleted, span.diffstat .diffstat-bar i.minus,
-  .markdown-body del *, .markdown-body .removed *, .tooltipped-n span.octicon.octicon-x {
+  .markdown-body del *, .markdown-body .removed *, .status-failure .octicon {
     color: #c31e16 !important;
   }
   /* === Brown panel === */


### PR DESCRIPTION
Failed Travis builds should have a red "X" next to the commit ID

![untitled](https://cloud.githubusercontent.com/assets/5256208/2623763/d59e9ed6-bd05-11e3-870c-4341cd44e8cb.png)
