### PR TITLE
Infotip: use bright text color

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -857,7 +857,7 @@
   .full-commit .authorship .author-name, .showcase-featured .featured-grid-link, .collection-card-title,
   .collection-card-image:hover, .explore-page .see-more-link, .mute, .pull-request-link:hover, .expandable:hover:before,
   .sunken-menu .sunken-menu-item.selected, .follow-list .follow-list-name a, .member-list-item .member-info a,
-  a.comment-header-author, .callout strong, .select-menu-item.navigation-focus .octicon:before, .wiki-edit-link:hover {
+  a.comment-header-author, .callout strong, .select-menu-item.navigation-focus .octicon:before, .wiki-edit-link:hover, .infotip p {
     color: #eee !important;
   }
   pre, body, h3, h4, a.social-count, span.social-count, #languages a.bar, dl.form dt, .lineoption p, .vcard-stat-count,


### PR DESCRIPTION
Hopefully this doesn't break anything. Here's what it looked like before:

![untitled](https://cloud.githubusercontent.com/assets/5256208/3077782/db1736ac-e442-11e3-86f2-d2a2895a0975.png)

You can see for yourself [here](https://gist.github.com/).
