### PR TITLE
Change blog-feedback bg color

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -290,7 +290,7 @@
   .counter, .issues td, ul.main_nav li.selected, .browser_header, .issue-head, .bootcamp-help .image, ul.hook-list,
   .clone-url-button, .list-tip li, .section-nav a, .search-menu-container,
   .repo_list li a, .graphs .axis, .switcher > span:after, a.assignee-bit, .menu li, .notifications td, .filter-tab,
-  ul.hook-list li, .repo .border, .box-action, ul.repo-stats li a, .footer_nav h4, .footer-divider, .blog-feedback,
+  ul.hook-list li, .repo .border, .box-action, ul.repo-stats li a, .footer_nav h4, .footer-divider,
   .chromed-list-browser, .js-activate-link, .chromed-list-browser div, .filter-bar, .columns.sidebar, .title, .lbl,
   .participation-graph canvas, #contributors .person, .tabnav, #commit-activity-master, #services,
   .top-rule, .blog-post, #services .service, ul.stats, .select-menu-filters, .select-menu-item, .select-menu-tabs,
@@ -481,7 +481,7 @@
   #wiki-history table td, .commit.file-history-tease, .menu a.selected, .gist .gist-file .gist-data, .repository-lang-stats,
   #message.major, .branch-status, .logo-box, .commit-form, .markdown-example .rendered, .team-grid .team-members,
   .diagram-icon:not(.active), table.capped-list th, .ace_active-line, .ace_gutter-active-line, .overall-summary,
-  .scope-badge, .filter-bar, .audit-search-clear, .country-info, .tabnav-tab.selected, .file-diff-split .empty-cell, .blog-feedback {
+  .scope-badge, .filter-bar, .audit-search-clear, .country-info, .tabnav-tab.selected, .file-diff-split .empty-cell {
     background: #222 !important;
   }
   /* Darkest background color (#222), no image, with border & radius */
@@ -505,7 +505,8 @@
   #watchers li, .browser .listing, .item, .context-pane, .context-loader, .sidebar .module, .tip-body, #assignee, .rule,
   .sidebar-module > ul, .commit_oneline td, #footer-push, .notifications th, .content table, .inline-comments .tabnav,
   .comparison-list, .comparison-list .title, .repo-collection>ul, #graph_data .tab.selected, .line-comments, .full-width-divider,
-  h3.conversation-list-heading strong, .file-commit-form .commit-form, .thread-subscription-status, .wiki-wrapper .wiki-empty-box {
+  h3.conversation-list-heading strong, .file-commit-form .commit-form, .thread-subscription-status, .wiki-wrapper .wiki-empty-box,
+  .blog-feedback {
     background-color: #222 !important;
     border-color: #555 !important;
   }


### PR DESCRIPTION
For [GitHub's blog](https://github.com/blog/1884-introducing-split-diffs).

Before:
![screen shot 2014-09-04 at 14 47 16](https://cloud.githubusercontent.com/assets/867840/4146654/b0c961f6-340e-11e4-89d8-06eb42b17873.png)

After:
![screen shot 2014-09-04 at 15 33 44](https://cloud.githubusercontent.com/assets/867840/4146664/d3bf49be-340e-11e4-8e27-8f19a1f366f7.png)
