### PR TITLE
Fix typo in class name for yellow flash message

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1163,7 +1163,7 @@
   /* === Yellow panel === */
   .branch-status.status-pending .discussion-item-icon, .discussion-event-status-renamed .discussion-item-icon,
   .state-indicator.renamed, .discussion-topic .branch-status.status-pending, .secret .repo-label span, .compare-pr-placeholder,
-  .compare-cutoff, .diff-cutoff, .flash.flash-warn, .flash-global.flash-war {
+  .compare-cutoff, .diff-cutoff, .flash.flash-warn, .flash-global.flash-warn {
     background: #383812 !important;
     border-color: #884 !important;
     color: #aa6 !important;


### PR DESCRIPTION
Before : ![Imgur](http://i.imgur.com/tzhZSpj.png)
After : ![Imgur](http://i.imgur.com/HyevUz1.png)