### PR TITLE
Fix pull request icon color

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1266,7 +1266,7 @@
     background: #6E5494 !important;
   }
   /* purple text */
-  ul.summary-stats li .octicon-git-pull-request, .pull-request-notification .type-icon {
+  ul.summary-stats li .octicon-git-pull-request, .pull-request-notification .type-icon .type-icon-state-merged {
     color: #6E5494 !important;
   }
   .diagram-icon-small.active .mega-octicon:before {


### PR DESCRIPTION
In the notification panel, all PRs are seen in purple, even if they've got different states.
This quick fix resolves this.