### PR TITLE
Commit: fix "committed for" in author section

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1508,7 +1508,7 @@
   .dropdown-header, .participation a, .completeness-indicator-info,
   .type-icon-state-none, a.type-icon-state-none, .pagehead-tabs-item,
   a.pagehead-tabs-item, .org-settings-team-count, a.muted-link strong,
-  table.files td.icon, .commit-tease {
+  table.files td.icon, .commit-tease, .commit-author-section {
     color: #808080 !important;
   }
   .vcard-detail .octicon, .member-badge .octicon,


### PR DESCRIPTION
This fixes the "committed for" part of the author section of commits and commit teases, which appears when the committer is not the author.

Example: https://github.com/vim-scripts/taglist.vim