### PR TITLE
Darkerize commit meta

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -715,6 +715,10 @@
     background: #181818 !important;
     border-color: #343434 !important;
   }
+  .commit-tease .commit-meta {
+    background-color: #1D1D1D !important;
+    border-top: #1D1D1D;
+  }
   #readme .plain, .readme .markdown-body, .readme .plain, .pull-request-composer,
   .drag-and-drop, .octofication .broadcast-icon-mask, .file .image,
   .merge-pr-more-commits, .release-timeline-tags .expander-dots,

--- a/github-dark.css
+++ b/github-dark.css
@@ -584,7 +584,7 @@
   .migrate-org-roles, .migrate-org-roles-header, .migrate-org-roles-item,
   .migrate-org-roles-count, .migration-footer, .migration-feature-list:before,
   .migration-org-avatar, .org-migration-settings-section,
-  .word-upload-callout .note {
+  .word-upload-callout .note, .commit-tease .commit-meta {
     border-color: #343434 !important;
   }
   .discussion-item-icon, .date:after, .render-shell img, img.asset,
@@ -715,10 +715,6 @@
     background: #181818 !important;
     border-color: #343434 !important;
   }
-  .commit-tease .commit-meta {
-    background-color: #1D1D1D !important;
-    border-top: #1D1D1D;
-  }
   #readme .plain, .readme .markdown-body, .readme .plain, .pull-request-composer,
   .drag-and-drop, .octofication .broadcast-icon-mask, .file .image,
   .merge-pr-more-commits, .release-timeline-tags .expander-dots,
@@ -752,7 +748,8 @@
   .oauth-org-access-details .boxed-group-list > li.on, #fullscreen_overlay,
   .timeline-new-comment .discussion-topic-header, .branch-action-body,
   .inline-comment-form, .file-history-tease .participation,
-  .gist-quicksearch-result-header, .label-generic, .migrate-org-roles {
+  .gist-quicksearch-result-header, .label-generic, .migrate-org-roles,
+  .commit-tease .commit-meta {
     background: #181818 !important;
   }
   .markdown-body table tr, .blob-num-context {


### PR DESCRIPTION
The commit meta are shown with a white background (at least on Github enterprise).

![2015-10-27_11-01-10](https://cloud.githubusercontent.com/assets/471070/10754794/4eb233f0-7c9a-11e5-8a2d-56983216c4ce.gif)
