### PR TITLE
Update for new GitHub Repository View

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -592,7 +592,8 @@
   .migrate-org-roles, .migrate-org-roles-header, .migrate-org-roles-item,
   .migrate-org-roles-count, .migration-footer, .migration-feature-list:before,
   .migration-org-avatar, .org-migration-settings-section,
-  .word-upload-callout .note, .commit-tease .commit-meta {
+  .word-upload-callout .note, .commit-tease .commit-meta,
+  .js-selected-navigation-item.selected.reponav-item {
     border-color: #343434 !important;
   }
   .discussion-item-icon, .date:after, .render-shell img, img.asset,
@@ -658,7 +659,8 @@
   .select-menu-button::before {
     border-top-color: #eee !important;
   }
-  .pagehead-tabs-item.selected {
+  .pagehead-tabs-item.selected,
+  .js-selected-navigation-item.selected.reponav-item {
     border-bottom-color: #222 !important;
     border-top-width: 1px !important;
   }
@@ -813,7 +815,8 @@
   .file-diff-split .empty-cell, .composer-infobar, .completeness-indicator-blank,
   .leaflet-control-zoom,
   .leaflet-container .leaflet-control-attribution.leaflet-compact-attribution,
-  .pagehead-tabs-item.selected {
+  .pagehead-tabs-item.selected,
+  .js-selected-navigation-item.selected.reponav-item {
     background: #222 !important;
   }
   hr, .rule, #browser, .repos, .options-group, .pagehead ul.tabs li a.selected,
@@ -1454,7 +1457,7 @@
   .pagehead-tabs-item.selected, a.pagehead-tabs-item.selected,
   .pagehead-tabs-item:hover, a.pagehead-tabs-item:hover, .article-meta,
   a.article-meta, .timeline-comment-header-text code a, .commit-tease-sha,
-  a.commit-tease-sha {
+  a.commit-tease-sha, .js-selected-navigation-item.selected.reponav-item {
     color: #c0c0c0 !important;
   }
   h5, h6, .edit-repository-meta, .field label, .boxed-group-list li, .capped-box,
@@ -1613,7 +1616,8 @@
   a.select-menu-item, .list-heading a, .close-button, .timeline-comment-action,
   a.timeline-comment-action, a.comment-type-icon,
   .timeline-comment-actions .octicon, .commit-title .commit-link tt,
-  .btn-block-user, .pagehead-tabs-item.selected > .octicon, .text-muted strong {
+  .btn-block-user, .pagehead-tabs-item.selected > .octicon, .text-muted strong,
+  .js-selected-navigation-item.selected.reponav-item > .octicon {
     color: inherit !important;
   }
   /* Alerts and activity, remove background gradient */

--- a/github-dark.css
+++ b/github-dark.css
@@ -540,6 +540,9 @@
   .gist-quicksearch-result-group {
     border-color: #484848 !important;
   }
+  a.reponav-item {
+    color: #888 !important;
+  }
   pre, h1, h2, h3, .header, #footer, table, table tr, table td, table th,
   blockquote, .pulse-graph, .btn:not(img), .minibutton, .social-count,
   .discusion-topic-infobar, .box-header, .box-body, .timeline-comment-label,

--- a/github-dark.css
+++ b/github-dark.css
@@ -593,7 +593,7 @@
   .migrate-org-roles-count, .migration-footer, .migration-feature-list:before,
   .migration-org-avatar, .org-migration-settings-section,
   .word-upload-callout .note, .commit-tease .commit-meta,
-  .js-selected-navigation-item.selected.reponav-item {
+  .reponav-item.selected {
     border-color: #343434 !important;
   }
   .discussion-item-icon, .date:after, .render-shell img, img.asset,
@@ -660,7 +660,7 @@
     border-top-color: #eee !important;
   }
   .pagehead-tabs-item.selected,
-  .js-selected-navigation-item.selected.reponav-item {
+  .reponav-item.selected {
     border-bottom-color: #222 !important;
     border-top-width: 1px !important;
   }
@@ -816,7 +816,7 @@
   .leaflet-control-zoom,
   .leaflet-container .leaflet-control-attribution.leaflet-compact-attribution,
   .pagehead-tabs-item.selected,
-  .js-selected-navigation-item.selected.reponav-item {
+  .reponav-item.selected {
     background: #222 !important;
   }
   hr, .rule, #browser, .repos, .options-group, .pagehead ul.tabs li a.selected,
@@ -1457,7 +1457,7 @@
   .pagehead-tabs-item.selected, a.pagehead-tabs-item.selected,
   .pagehead-tabs-item:hover, a.pagehead-tabs-item:hover, .article-meta,
   a.article-meta, .timeline-comment-header-text code a, .commit-tease-sha,
-  a.commit-tease-sha, .js-selected-navigation-item.selected.reponav-item {
+  a.commit-tease-sha, .reponav-item.selected {
     color: #c0c0c0 !important;
   }
   h5, h6, .edit-repository-meta, .field label, .boxed-group-list li, .capped-box,
@@ -1617,7 +1617,7 @@
   a.timeline-comment-action, a.comment-type-icon,
   .timeline-comment-actions .octicon, .commit-title .commit-link tt,
   .btn-block-user, .pagehead-tabs-item.selected > .octicon, .text-muted strong,
-  .js-selected-navigation-item.selected.reponav-item > .octicon {
+  .reponav-item.selected > .octicon {
     color: inherit !important;
   }
   /* Alerts and activity, remove background gradient */


### PR DESCRIPTION
As indicated at https://github.com/blog/2085-a-new-look-for-repositories, a new look for respositories is coming.  Some CSS has changed for the active tab, so this PR updates the CSS to apply the necessary styles for the new CSS.