### PR TITLE
New repos: Fix repository meta/description

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1461,7 +1461,7 @@
   }
   h5, h6, .edit-repository-meta, .field label, .boxed-group-list li, .capped-box,
   .marketing-nav a, .header .header-logo-invertocat span,
-  .repository-meta .repository-description, .gist-item .description, p.explain,
+  .repository-meta, .gist-item .description, p.explain,
   .news .alert .simple .title, #network .graph-date, .tabnav-widget.text,
   .feature .intro, span.diffstat, span.diffstat a, .commit .commit-branches a,
   #readme .plain, .select-menu-tabs a, .news blockquote, .news blockquote p,


### PR DESCRIPTION
The `.repository-description` class no longer exists in the new look, and is also not styled by GitHub in the old look.