### PR TITLE
Darken scroll bars for WebKit-based browsers (Safari, Google Chrome, etc.)

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2089,6 +2089,16 @@
     background: #300 !important;
     border-color: #500 !important;
   }
+  /* scroll bar */
+  ::-webkit-scrollbar {
+      background: #181818 !important;
+  }
+  ::-webkit-scrollbar-track {
+      background: #181818 !important;
+  }
+  ::-webkit-scrollbar-thumb {
+      background: #444 !important;
+  }
   /* GitHub Enterprise Only
    *                                 _____..---========+*+==========---.._____
    *    ______________________ __,-='=====____  =================== _____=====`=


### PR DESCRIPTION
This tiny snippet darkens both horizontal and vertical scroll bars of github.com on web browsers such as Safari, Google Chrome and Opera except for Firefox.  (Strictly speaking, Google Chrome no longer uses the WebKit engine, but `::-web-kit-scrollbar**` still works on the latest Google Chrome.)