### PR TITLE
darken webkit scrollbar corners

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2096,7 +2096,8 @@
     max-width: 12px !important;
     background: #181818 !important;
   }
-  ::-webkit-scrollbar-track {
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-corner {
     background: #181818 !important;
   }
   ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
I forgot to include `::-webkit-scrollbar-corner` selector in my last pull request (#272), which has already been committed to the master branch. So I am putting this separate pull request to add it. Without this selector, the bottom right corner (the intersection of the horizontal and vertical scroll bars), which appears only when both scroll bars are active like when Octotree sidebar is opened, does not turn dark gray and remains white. Sorry, I should have tested more thoroughly.