### PR TITLE
MediaWiki: Apply background-color to the TOC

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -768,7 +768,7 @@
   .issues-listing .table-list, #org-members .table-list {
     background: #181818 !important;
   }
-  .markdown-body table tr, .blob-num-context {
+  .markdown-body table tr, .blob-num-context, #user-content-toc td {
     background: #141414 !important;
   }
   .blame .blob-num, .blame-blob-num, .overall-summary, .repository-lang-stats,


### PR DESCRIPTION
Example: https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki

Before:

![](http://i.imgur.com/jkqNORm.png)

After:

![](http://i.imgur.com/bXSPYSa.png)