### PR TITLE
Constrict the horizontal scrollbar height

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2102,6 +2102,7 @@
   /* scroll bar */
   ::-webkit-scrollbar {
     max-width: 12px !important;
+    max-height: 10px !important;
     background: #181818 !important;
   }
   ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner {


### PR DESCRIPTION
This makes sure the horizontal scrollbar can not be any taller than 10 pixels

Previously the horizontal scrollbar looked a little large:

<img width="723" alt="screen shot 2015-12-31 at 13 46 14" src="https://cloud.githubusercontent.com/assets/283886/12068572/ecadc7dc-afc5-11e5-81f1-b4acca0195c5.png">

This makes it a little shorter:

<img width="741" alt="screen shot 2015-12-31 at 13 51 39" src="https://cloud.githubusercontent.com/assets/283886/12068575/fdd5eda0-afc5-11e5-8b67-970b2a8d133c.png">
