### PR TITLE
Sets contribution calendar color to white for contrast

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -925,13 +925,13 @@
     background-color: #333 !important;
     border-color: #484848 !important;
   }
-  /* contribution calender and blame heats */
+  /* contribution calendar and blame heats */
   .heat, .contrib-legend li, #contributions-calendar rect[fill="#d6e685"],
   #contributions-calendar rect[fill="#8cc665"],
   #contributions-calendar rect[fill="#44a340"],
   #contributions-calendar rect[fill="#1e6823"] {
-    background-color: /*[[base-color]]*/ #5af !important;
-    fill: /*[[base-color]]*/ #5af !important;
+    background-color: #fff !important;
+    fill: #fff !important;
   }
   /* halloween colors */
   #contributions-calendar rect[fill="#FFEE4A"],


### PR DESCRIPTION
This might be a bit controversial, and maybe there's a better way to go about it.

I use the Solarized theme with Github Dark, and my contribution calendar is very blue. The problem is, it's very hard to tell the lowest tier apart from black, and even harder to sort of "guage" the filled-in-ness of a contribution calendar with the theme (compared to the green on black), especially on certain monitors or brightness settings.

The white on black seems to work pretty well, and I think it looks nice too. If there's a better way I could implement this change, please let me know.

Old:
![2016-02-06-155434_745x297_scrot](https://cloud.githubusercontent.com/assets/440033/12869332/eff92490-cce9-11e5-9fb7-d8c43b6537a9.png)

New:
![2016-02-06-155354_737x294_scrot](https://cloud.githubusercontent.com/assets/440033/12869329/e15dba18-cce9-11e5-9cc1-ad105ace2edb.png)