### PR TITLE
Updated the header scope badge to the new github css.

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -20,7 +20,7 @@
     font-family: "/*[[font-choice]]*/",Consolas,"Liberation Mono",Menlo,Courier,monospace !important;
   }
   /* Base link/panel colors - text */
-  a:not([href*="/labels/"]), input[type="text"]:focus + .scope-badge, a strong,
+  a:not([href*="/labels/"]), input[type="text"]:focus + .header-search-scope, a strong,
   .profilecols ul.stats li a:hover strong, .plans-row .plan,
   .filters li.selected, .vcard-stat, .zeroclipboard-button,
   .creator a, button#logout:hover,
@@ -629,7 +629,7 @@
   .merge-branch-manually, .intgr-header, .code-list-item, .sort-bar,
   #com #footer, .repo-file-upload-outline, .comment-reactions.has-reactions,
   .reaction-summary-item, .select-menu-divider, .featurette.border-top,
-  .tile-block, .tile-bordered:not(:last-child) {
+  .tile-block, .tile-bordered:not(:last-child), .header-search-scope {
     border-color: #343434 !important;
   }
   .discussion-item-icon, .date:after, .render-shell img, img.asset,
@@ -848,7 +848,7 @@
   .search-results-listing em, .discussion-bubble-inner, #wiki-history table td,
   .menu a.selected, .gist .gist-file .gist-data, #message.major, .logo-box,
   .markdown-example .rendered, .team-grid .team-members,
-  .diagram-icon:not(.active), table.capped-list th, .scope-badge, .filter-bar,
+  .diagram-icon:not(.active), table.capped-list th, .header-search-scope, .filter-bar,
   .audit-search-clear, .country-info, .tabnav-tab.selected,
   .file-diff-split .empty-cell, .composer-infobar, .completeness-indicator-blank,
   .leaflet-control-zoom, .pagehead-tabs-item.selected, .reponav-item.selected,
@@ -1652,7 +1652,7 @@
   .issues-listing .table-list-issues .issue-comments-link,
   .issues-listing .table-list-issues .issue-meta-section a, a.issues-reset-query,
   .labels-list-action, table.tag-list p a, table.tag-list td.date a, .muted-link,
-  a.muted-link, .render-view-modes li, .scope-badge, .site-footer,
+  a.muted-link, .render-view-modes li, .header-search-scope, .site-footer,
   .site-footer .octicon-mark-github:hover, .repo-list-stats .repo-list-stat-item,
   .range-editor span.flag .octicon, .commit-info .commit-meta a,
   .notifications .issue-notification.read .type-icon, .notifications .read a,


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5570853/14005183/46cf5190-f161-11e5-95df-e28e8d7c91ff.png)
Instead of
![image](https://cloud.githubusercontent.com/assets/5570853/14005204/819f8c9a-f161-11e5-9089-0a1e991d10b4.png)
