### PR TITLE
Issues: style intro-shelf

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1291,7 +1291,7 @@
   .new-user-avatar-cta, .jstree-wholerow-clicked, .commit-ref, .api .alert,
   .file-history-tease, .flash, .flash-global, .feature-banner,
   .recently-touched-branches, .contributing, .comment-reactions .user-has-reacted,
-  .pr-toolbar .subset-files-tab {
+  .pr-toolbar .subset-files-tab, .intro-shelf {
     background: #182030 !important;
   }
   .repo-file-upload-progress .repo-file-upload-meter {


### PR DESCRIPTION
I wasn't sure how to style this element. It normally has a background gradient:

```css
background-image: linear-gradient(180deg, rgba(255,255,255,0) 60%, #fff),linear-gradient(70deg, #e0f1ff 32%, #fffae3)
```
I tried yellow but it didn't look right, and I took a look at the various gradients that already exist, but those didn't look good either, so I stuck with blue. Let me know what you think. You can find the unstyled element if you go to the main GitHub page after signing in (not your profile page). It's the page that shows your news feed.