### PR TITLE
Fix organizarion header colors

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -3484,3 +3484,8 @@
   }
   /* Literal.Number.Integer.Long */
 }
+
+.orghead {
+    background-color: transparent;
+    border-bottom-color: #333;
+}


### PR DESCRIPTION
Hello,

When I open any organization page, I see the header with a light color:
<img width="1286" alt="captura de tela 2016-06-26 as 22 23 58" src="https://cloud.githubusercontent.com/assets/6557756/16366364/d9fc1b08-3bec-11e6-9da3-8cbb87768a49.png">

So, I added the follow lines at the end of my local stylesheet and the problem was fixed:
```
.orghead {
   background-color: transparent;
   border-bottom-color: #333;
}
```
<img width="1284" alt="captura de tela 2016-06-26 as 22 24 17" src="https://cloud.githubusercontent.com/assets/6557756/16366388/1fcf9f7e-3bed-11e6-9dfd-0a35a1375dac.png">

I believe that the end of file is not a good place for my change, but I don't know where it could be.