### PR TITLE
User profile tabs: add base-color top border on selected tab

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -739,7 +739,8 @@
   .select-menu-button:before {
     border-top-color: #eee !important;
   }
-  .pagehead-tabs-item.selected, .reponav-item.selected, .btn-link.selected {
+  .pagehead-tabs-item.selected, .reponav-item.selected, .btn-link.selected,
+  .tabnav-tab.selected {
     border-bottom-color: #222 !important;
     border-top-width: 3px !important;
     border-top-color: /*[[base-color]]*/ #4183C4 !important;


### PR DESCRIPTION
Essentially this, before and after below

![tabs](https://cloud.githubusercontent.com/assets/3521959/16901093/e2a7bb46-4c30-11e6-9499-bda6fa4832b1.gif)

