### PR TITLE
enhancement: add https://github.com/ bottom page rss icon to orange style

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2303,7 +2303,7 @@
   }
   /* orange rss icon */
   .blog-aside .octicon-rss, .dashboard-feed-icon.octicon-rss,
-  .nav-rss a .octicon-rss, a.feed-icon {
+  .nav-rss a .octicon-rss, a.feed-icon, .mr-2 {
     color: #f93 !important;
   }
   .featured-label {


### PR DESCRIPTION
This fixes consistency with other rss icon colors

Before and after

![rss](https://cloud.githubusercontent.com/assets/3521959/16932995/29adbdc6-4d42-11e6-8a8b-b74824ca7c1c.gif)
