### PR TITLE
add subdomain: darken https://services.github.com/

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1,4 +1,4 @@
-@-moz-document regexp("^https?://((gist|guides|help|raw|status|developer)\.)?github\.com((?!generated_pages\/preview).)*$"), domain("render.githubusercontent.com"), domain("raw.githubusercontent.com") {
+@-moz-document regexp("^https?://((gist|guides|help|raw|status|services|developer)\.)?github\.com((?!generated_pages\/preview).)*$"), domain("render.githubusercontent.com"), domain("raw.githubusercontent.com") {
   /*! Github Dark Theme v1.14.91 (7/18/2016) *//*
  * https://github.com/StylishThemes/GitHub-Dark
  * http://userstyles.org/styles/37035


### PR DESCRIPTION
like it says on the tin

Seems to work very well

its accessed via Training link on footer

![capture](https://cloud.githubusercontent.com/assets/3521959/16944021/90a91724-4d96-11e6-9db8-981fb09b6773.PNG)
