### PR TITLE
fix baby sh*t color styles and make text color over alert boxes consistent

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1663,7 +1663,7 @@
   .blog .text-delta, .blog .text-gamma, .blog h1, .blog h2, .blog h3, .blog h4,
   .blog h5, .site-header-nav a, .menu-item.selected, .overview .text-beta,
   article h2, #message-list h1, #message-list h3, .graph-page h1,
-  .graph-page h3 {
+  .graph-page h3, .comment-form-error, .comment-form-stale {
     color: #e2e2e2 !important;
   }
   pre, body, a.social-count, span.social-count, #languages a.bar, .lineoption p,
@@ -1979,7 +1979,7 @@
   .type-icon-state-closed, a.type-icon-state-closed, .reverted.octicon,
   .delete-owners-button:hover, .dangerzone-module h4, .btn-octicon-danger:hover,
   .deprecation-notice a, .billing-addon-items tr.total-row *,
-  .comment-form-error, .comment-form-stale, .markdown-body .absent, .text-red,
+  .markdown-body .absent, .text-red,
   a.text-red, .flash-error {
     color: #e6271e !important;
   }

--- a/github-dark.css
+++ b/github-dark.css
@@ -1959,8 +1959,8 @@
   /* red border */
   .mergeable-dirty .bubble .mergeable, #message.major, .comment-form-error,
   .comment-form-stale, .deprecation-notice, .flash-error {
-    border-color: #f44 !important;
-    background: #300 !important;
+    border-color: #911 !important;
+    background: #500 !important;
   }
   .mergeable-dirty .bubble:after {
     border-right-color: #911 !important;
@@ -1981,7 +1981,7 @@
   .deprecation-notice a, .billing-addon-items tr.total-row *,
   .comment-form-error, .comment-form-stale, .markdown-body .absent, .text-red,
   a.text-red, .flash-error {
-    color: #f44 !important;
+    color: #e6271e !important;
   }
   /* purple */
   .illflow-item.selected {


### PR DESCRIPTION
Im sorry, but the color style picked to the red alert boxes is simply awful (there isnt a good compromise that way imo aside from this)

Following GitHub defaults/styles (ON DARK) should only be done with a pinch of salt on very few selected items. (unless you dont care about aesthetics or visibility or users with visual impairments)

this reverts the last two commits and add the missing selector `.comment-form-stale` to same style group as `comment-form-error`

@silverwind is bound to disagree with this, because he loves this awful stuff and swears by it, but its simply unreadable and his attempts to make it readable made it look simply awful.

and appeal to common sense @Mottie
