### PR TITLE
fix background in payments for failed/refunded txn

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -942,7 +942,8 @@
   .ajax-pagination-form .ajax-pagination-btn:hover,
   .ajax-pagination-form .ajax-pagination-btn:focus,
   .manage-repo-access-not-active, .header-search-scope, .reverse-progress-bar,
-  .featurette.py-5, .ace_button:hover {
+  .featurette.py-5, .ace_button:hover,
+  .payment-history .refunded, .payment-history .failed, {
     background: #222 !important;
   }
   hr, .rule, #browser, .repos, .options-group, .pagehead ul.tabs li a.selected,


### PR DESCRIPTION
Fixes the table row background for `.failed` and `.refunded` rows within
the `.payment-history` table available on https://github.com/settings/billing

before:
<img width="593" alt="screen shot 2016-09-06 at 22 09 21z" src="https://cloud.githubusercontent.com/assets/210924/18292852/1442f2e4-747f-11e6-8b22-661740c721a7.png">

after:
<img width="573" alt="screen shot 2016-09-06 at 22 09 01z" src="https://cloud.githubusercontent.com/assets/210924/18292860/1b42daf0-747f-11e6-9ddd-65e508c6ae83.png">
