### PR TITLE
Added Monokai - Spacegray Eighties theme from Sublime Text

### DIFF
--- a/themes/codemirror/monokai-spacegray-eighties.css
+++ b/themes/codemirror/monokai-spacegray-eighties.css
@@ -1,0 +1,34 @@
+/* Monokai - Spacegray Eighties
+https://github.com/pyoio/monokai-spacegray */
+.CodeMirror { background: #1C1C1C !important; color: #F8F8F8 !important; }
+.CodeMirror-selected { background: #3C3C3C !important; }
+.CodeMirror-line::selection, .CodeMirror-line > span::selection,
+.CodeMirror-line > span > span::selection { background: rgba(44, 44, 44, .99) !important; }
+.CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection,
+.CodeMirror-line > span > span::-moz-selection { background: rgba(44, 44, 44, .99) !important; }
+.CodeMirror-gutters { background: #1C1C1C !important; border-right: 0 !important; }
+.CodeMirror-guttermarker { color: #B9B9B9 !important; }
+.CodeMirror-guttermarker-subtle { color: #8A8A8A !important; }
+.CodeMirror-linenumber { color: #8A8A8A !important; }
+.CodeMirror-cursor { border-left: 1px solid #f8f8f0 !important; }
+.cm-comment { color: #808080 !important; }
+.cm-atom { color: #AE81FF !important; }
+.cm-number { color: #AE81FF !important; }
+.cm-property, span.cm-attribute { color: #a6e22e !important; }
+.cm-keyword { color: #66D9EF !important; font-style: italic !important; }
+.cm-builtin { color: #F8F8F8 !important; }
+.cm-string { color: #E6DB74 !important; }
+.cm-variable { color: #F8F8F8 !important; }
+.cm-variable-2 { color: #9effff !important; }
+.cm-variable-3 { color: #AE81FF !important; }
+.cm-def { color: #66D9EF !important; font-style: italic !important; }
+.cm-bracket { color: #F8F8F8 !important; }
+.cm-tag { color: #F92672 !important; }
+.cm-header { color: #ae81ff !important; }
+.cm-link { color: #ae81ff !important; }
+.cm-error { background: #1e0010 !important; color: #960050 !important; }
+.CodeMirror-activeline-background { background: #2C2C2C !important; }
+.CodeMirror-matchingbracket {
+  text-decoration: underline !important;
+  color: #F8F8F8 !important;
+}

--- a/themes/github/monokai-spacegray-eighties.css
+++ b/themes/github/monokai-spacegray-eighties.css
@@ -1,0 +1,103 @@
+/*! Monokai - Spacegray Eighties
+https://github.com/pyoio/monokai-spacegray */
+.highlight, .CodeMirror {
+  background-color: #1C1C1C !important;
+  color: #F8F8F8 !important;
+}
+.blob-code, .blob-code-inner {
+  color: #F8F8F8 !important;
+}
+.pl-c, .pl-c span{ color: #808080 !important; } /* comment */
+.pl-c1 { color: #66D9EF !important; } /* constant */
+.pl-cce { color: #66D9EF !important; } /* constant.character.escape */
+.pl-cn { color: #AE81FF !important; } /* constant.numeric */
+.pl-coc { color: #AE81FF !important; } /* constant.other.color */
+.pl-cos { color: #E6DB74 !important; } /* constant.other.symbol */
+.pl-e { color: #F92672 !important; } /* entity */
+.pl-ef { color: #A6E22E !important; } /* entity.function */
+.pl-en { color: #A6E22E !important; } /* entity.name */
+.pl-enc { color: #66D9EF !important; } /* entity.name.class */
+.pl-enf { color: #A6E22E !important; } /* entity.name.function */
+.pl-enm { color: #A6E22E !important; } /* entity.name.method-name */
+.pl-ens { color: #66D9EF !important; } /* entity.name.section */
+.pl-ent { color: #F92672 !important; } /* entity.name.tag */
+.pl-entc { color: #A6E22E !important; } /* entity.name.type.class */
+.pl-enti { color: #A6E22E !important; font-weight: bold !important; } /* entity.name.type.instance */
+.pl-entm { color: #A6E22E !important; } /* entity.name.type.module */
+.pl-eoa { color: #F92672 !important; } /* entity.other.attribute-name */
+.pl-eoac { color: #A6E22E !important; } /* entity.other.attribute-name.class */
+.pl-eoac .pl-pde { color: #A6E22E !important; } /* punctuation.definition.entity */
+.pl-eoai { color: #F92672 !important; } /* entity.other.attribute-name.id */
+.pl-eoai .pl-pde { color: #F92672 !important; } /* punctuation.definition.entity */
+.pl-eoi { color: #A6E22E !important; } /* entity.other.inherited-class */
+.pl-k { color: #F92672 !important; } /* keyword */
+.pl-ko { color: #F92672 !important; } /* keyword.operator */
+.pl-kolp { color: #F92672 !important; } /* keyword.operator.logical.python */
+.pl-kos { color: #66D9EF !important; } /* keyword.other.special-method */
+.pl-kou { color: #66D9EF !important; } /* keyword.other.unit */
+.pl-mai .pl-sf { color: #A6E22E !important; } /* support.function */
+.pl-mb { color: #E6DB74 !important; font-weight: bold !important; } /* markup.bold */
+.pl-mc { color: #F92672 !important; } /* markup.changed */
+.pl-mh .pl-pdh { color: #66D9EF !important; } /* markup.heading punctuation.definition.heading */
+.pl-mi { color: #F92672 !important; font-style: italic !important; } /* markup.italic */
+.pl-ml { color: #E6DB74 !important; } /* markup.list */
+.pl-mm { color: #A6E22E !important; } /* meta.module-reference */
+.pl-mp { color: #66D9EF !important; } /* meta.property-name */
+.pl-mp1 .pl-sf { color: #66D9EF !important; } /* meta.property-value support.function */
+.pl-mq { color: #66D9EF !important; } /* markup.quote */
+.pl-mr { color: #F92672 !important; } /* meta.require */
+.pl-ms { color: #F92672 !important; } /* meta.selector */
+.pl-pdb { color: #E6DB74 !important; font-weight: bold !important; } /* punctuation.definition.bold */
+.pl-pdc { color: #75715E !important; font-style: italic !important; } /* punctuation.definition.comment */
+.pl-pdc1 { color: #AE81FF !important; } /* punctuation.definition.constant */
+.pl-pde { color: #66D9EF !important; } /* punctuation.definition.entity */
+.pl-pdi { color: #F92672 !important; font-style: italic !important; } /* punctuation.definition.italic */
+.pl-pds { color: #F8F8F8 !important; } /* punctuation.definition.string */
+.pl-pdv { color: #A6E22E !important; } /* punctuation.definition.variable */
+.pl-pse { color: #66D9EF !important; } /* punctuation.section.embedded */
+.pl-pse .pl-s2 { color: #66D9EF !important; } /* punctuation.section.embedded source */
+.pl-s { color: #E6DB74 !important; } /* storage */
+.pl-s1 { color: #E6DB74 !important; } /* string */
+.pl-s2 { color: #F8F8F8 !important; } /* source */
+.pl-mp .pl-s3 { color: #66D9EF !important; } /* support */
+.pl-s3 { color: #F92672 !important; } /* support */
+.pl-sc { color: #FD971F !important; } /* support.class */
+.pl-scp { color: #AE81FF !important; } /* support.constant.property-value */
+.pl-sf { color: #FD971F !important; } /* support.function */
+.pl-smc { color: #F92672 !important; } /* storage.modifier.c */
+.pl-smi { color: #FD971F !important; } /* storage.modifier.import */
+.pl-smp { color: #F92672 !important; } /* storage.modifier.package */
+.pl-sok { color: #F92672 !important; } /* support.other.keyword */
+.pl-sol { color: #E6DB74 !important; } /* string.other.link */
+.pl-som { color: #A6E22E !important; } /* support.other.module */
+.pl-sr { color: #A6E22E !important; } /* string.regexp */
+.pl-sra { color: #F92672 !important; } /* string.regexp string.regexp.arbitrary-repetition */
+.pl-src { color: #F92672 !important; } /* string.regexp.character-class */
+.pl-sre { color: #F92672 !important; } /* string.regexp source.ruby.embedded */
+.pl-st { color: #66d9ef !important; } /* support.type */
+.pl-stj { color: #F8F8F8 !important; } /* storage.type.java */
+.pl-stp { color: #F92672 !important; } /* support.type.property-name */
+.pl-sv { color: #F92672 !important; } /* support.variable */
+.pl-v { color: #F92672 !important; } /* variable */
+.pl-vi { color: #F92672 !important; } /* variable.interpolation */
+.pl-vo { color: #A6E22E !important; } /* variable.other */
+.pl-vpf { color: #F92672 !important; } /* variable.parameter.function */
+/* Diff - Example: https://gist.github.com/silverwind/904159f1e71e2e626375 */
+.pl-mi1 { color: #A6E22E !important; background: rgba(0, 64, 0, .5) !important; } /* markup.inserted */
+.pl-mdht { color: #A6E22E !important; background: rgba(0, 64, 0, .5) !important; } /* meta.diff.header.to-file */
+.pl-md { color: #f92672 !important; background: rgba(64, 0, 0, .5) !important; } /* markup.deleted */
+.pl-mdhf { color: #f92672 !important; background: rgba(64, 0, 0, .5) !important; } /* meta.diff.header.from-file */
+.pl-mdr { color: #66D9EF !important; font-weight: normal !important; } /* meta.diff.range */
+.pl-mdh { color: #A6E22E !important; font-weight: normal !important; } /* meta.diff.header */
+.pl-mdi { color: #A6E22E !important; font-weight: normal !important; } /* meta.diff.index */
+/* TODO: Fix unstyled classes below */
+.pl-ib { background-color: #A6E22E !important; color: #272822 !important; } /* invalid.broken */
+.pl-id { background-color: #A6E22E !important; color: #272822 !important; } /* invalid.deprecated */
+.pl-ii { background-color: #A6E22E !important; color: #272822 !important; } /* invalid.illegal */
+.pl-iu { background-color: #A6E22E !important; color: #272822 !important; } /* invalid.unimplemented */
+.pl-mo { color: #FD971F !important; } /* meta.output */
+.pl-mri { color: #66D9EF !important; } /* markup.raw.inline */
+.pl-ms1 { background-color: #FD971F !important; } /* meta.separator */
+.pl-va { color: #66D9EF !important; } /* variable.assignment */
+.pl-vpu { color: #66D9EF !important; } /* variable.parameter.url */
+.pl-entl { color: #FD971F !important; } /* entity.name.tag.label */

--- a/themes/jupyter/monokai-spacegray-eighties.css
+++ b/themes/jupyter/monokai-spacegray-eighties.css
@@ -1,0 +1,62 @@
+/* Jupyter Notebooks; Monokai - Spacegray Eighties
+https://github.com/pyoio/monokai-spacegray */
+#notebook .highlight table { background-color: #1C1C1C !important; color: #F8F8F8 !important; }
+.highlight .hll { background-color: #2C2C2C !important; }
+.highlight .c { color: #808080 !important; } /* Comment */
+.highlight .err { color: #960050 !important; background-color: #1e0010 !important; } /* Error */
+.highlight .k { color: #66D9EF !important; font-style: italic !important; } /* Keyword */
+.highlight .l { color: #AE81FF !important; } /* Literal */
+.highlight .n, .highlight .h { color: #F8F8F8 !important; } /* Name */
+.highlight .o { color: #F92672 !important; } /* Operator */
+.highlight .p { color: #F8F8F8 !important; } /* Punctuation */
+.highlight .cm { color: #808080 !important; } /* Comment.Multiline */
+.highlight .cp { color: #808080 !important; } /* Comment.Preproc */
+.highlight .c1 { color: #808080 !important; } /* Comment.Single */
+.highlight .cs { color: #808080 !important; } /* Comment.Special */
+.highlight .ge { } /* Generic.Emph */
+.highlight .gs { } /* Generic.Strong */
+.highlight .kc { color: #AE81FF !important; } /* Keyword.Constant */
+.highlight .kd { color: #66D9EF !important; font-style: italic !important; } /* Keyword.Declaration */
+.highlight .kn { color: #F92672 !important; } /* Keyword.Namespace */
+.highlight .kp { color: #AE81FF !important; } /* Keyword.Pseudo */
+.highlight .kr { color: #AE81FF !important; } /* Keyword.Reserved */
+.highlight .kt { color: #66D9EF !important; font-style: italic !important; } /* Keyword.Type */
+.highlight .ld { color: #E6DB74 !important; } /* Literal.Date */
+.highlight .m { color: #AE81FF !important; } /* Literal.Number */
+.highlight .s { color: #E6DB74 !important; } /* Literal.String */
+.highlight .na { color: #A6E22E !important; } /* Name.Attribute */
+.highlight .nb { color: #F8F8F8 !important; } /* Name.Builtin */
+.highlight .nc { color: #A6E22E !important; font-style: italic !important; } /* Name.Class */
+.highlight .no { color: #AE81FF !important; } /* Name.Constant */
+.highlight .nd { color: #A6E22E !important; } /* Name.Decorator */
+.highlight .ni { color: #F92672 !important; } /* Name.Entity */
+.highlight .ne { color: #A6E22E !important; } /* Name.Exception */
+.highlight .nf { color: #A6E22E !important; } /* Name.Function */
+.highlight .nl { color: #F8F8F8 !important; } /* Name.Label */
+.highlight .nn { color: #F8F8F8 !important; } /* Name.Namespace */
+.highlight .nx { color: #F8F8F8 !important; } /* Name.Other */
+.highlight .py { color: #F92672 !important; } /* Name.Property */
+.highlight .nt { color: #F92672 !important; } /* Name.Tag */
+.highlight .nv { color: #F92672 !important; } /* Name.Variable */
+.highlight .ow { color: #F92672 !important; } /* Operator.Word */
+.highlight .w { color: #F8F8F8 !important; } /* Text.Whitespace */
+.highlight .mf { color: #AE81FF !important; } /* Literal.Number.Float */
+.highlight .mh { color: #AE81FF !important; } /* Literal.Number.Hex */
+.highlight .mi { color: #AE81FF !important; } /* Literal.Number.Integer */
+.highlight .mo { color: #AE81FF !important; } /* Literal.Number.Oct */
+.highlight .sb { color: #E6DB74 !important; } /* Literal.String.Backtick */
+.highlight .sc { color: #E6DB74 !important; } /* Literal.String.Char */
+.highlight .sd { color: #E6DB74 !important; } /* Literal.String.Doc */
+.highlight .s2 { color: #E6DB74 !important; } /* Literal.String.Double */
+.highlight .se { color: #AE81FF !important; } /* Literal.String.Escape */
+.highlight .sh { color: #E6DB74 !important; } /* Literal.String.Heredoc */
+.highlight .si { color: #E6DB74 !important; } /* Literal.String.Interpol */
+.highlight .sx { color: #E6DB74 !important; } /* Literal.String.Other */
+.highlight .sr { color: #E6DB74 !important; } /* Literal.String.Regex */
+.highlight .s1 { color: #E6DB74 !important; } /* Literal.String.Single */
+.highlight .ss { color: #E6DB74 !important; } /* Literal.String.Symbol */
+.highlight .bp { color: #F92672 !important; } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #F92672 !important; } /* Name.Variable.Class */
+.highlight .vg { color: #F92672 !important; } /* Name.Variable.Global */
+.highlight .vi { color: #F92672 !important; } /* Name.Variable.Instance */
+.highlight .il { color: #AE81FF !important; } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
tmTheme source:
https://github.com/pyoio/monokai-spacegray

It seems GitHub doesn't apply separate css classes some elements that it should and so the theme, unfortunately, isn't exactly like it appears in Sublime but it's close enough.

Only tested the appearance with Python, javascript and xml files but I think it should look fine with other languages on GitHub.