### PR TITLE
fix contrib calendar heats and cleanup

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1132,7 +1132,7 @@
   .calendar-graph rect[fill="#d6e685"],
   .calendar-graph rect[fill="#8cc665"],
   .calendar-graph rect[fill="#44a340"],
-  .calendar-graph rect[fill="#1e6823"], .heat {
+  .calendar-graph rect[fill="#1e6823"] {
     background-color: /*[[base-color]]*/ #5af !important;
     fill: /*[[base-color]]*/ #5af !important;
   }

--- a/github-dark.css
+++ b/github-dark.css
@@ -1129,7 +1129,7 @@
     border-color: #484848 !important;
   }
   /* contribution calendar and blame heats */
-  .heat, .contrib-legend li, .calendar-graph rect[fill="#d6e685"],
+  .heat, .calendar-graph rect[fill="#d6e685"],
   .calendar-graph rect[fill="#8cc665"], .calendar-graph rect[fill="#44a340"],
   .calendar-graph rect[fill="#1e6823"] {
     background-color: /*[[base-color]]*/ #5af !important;

--- a/github-dark.css
+++ b/github-dark.css
@@ -1129,9 +1129,10 @@
     border-color: #484848 !important;
   }
   /* contribution calendar and blame heats */
-  .heat, .calendar-graph rect[fill="#d6e685"],
-  .calendar-graph rect[fill="#8cc665"], .calendar-graph rect[fill="#44a340"],
-  .calendar-graph rect[fill="#1e6823"] {
+  .calendar-graph rect[fill="#d6e685"],
+  .calendar-graph rect[fill="#8cc665"],
+  .calendar-graph rect[fill="#44a340"],
+  .calendar-graph rect[fill="#1e6823"], .heat {
     background-color: /*[[base-color]]*/ #5af !important;
     fill: /*[[base-color]]*/ #5af !important;
   }


### PR DESCRIPTION
First commit fixes this

![store](https://cloud.githubusercontent.com/assets/3521959/19358566/4099ccc6-916e-11e6-9751-6cd51399780b.gif)

second commit rearranges selectors

3rd commit fixes blame heats

![store](https://cloud.githubusercontent.com/assets/3521959/19358756/04853b48-916f-11e6-91c9-23838bf17ad0.gif)


Of course this could be fixed as it was before using base color but that is for whoever wants to figure that bit out and in that case close this.
