### PR TITLE
Added CSS selector to cover "event-created" id

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1262,7 +1262,7 @@
   /* invert #fff to #181818 */
   /* https://github.com/sujitpal/statlearning-notebooks/blob/master/src/chapter2.ipynb */
   .output_area img, table.pricing-table, div[id^="event-first"] img,
-  div[id^="event-joined-github"] img, .project-preview-img img {
+  div[id^="event-joined-github"] img, div[id^="event-created"] img, .project-preview-img img {
     -webkit-filter: invert(90.5%) hue-rotate(180deg) saturate(200%) !important;
             filter: invert(90.5%) hue-rotate(180deg) saturate(200%) !important;
   }


### PR DESCRIPTION
Child images of `event-created` id added to CSS filters.  Resolves #434.

Note: Github itself seems to have a CSS bug for the first issue image/text where the image overlaps the text.  Apparent even with Github-Dark switched off.

![screen shot 2016-10-17 at 11 26 09 pm](https://cloud.githubusercontent.com/assets/5793364/19443955/20fc8484-94c1-11e6-9ad7-08654340cf4a.png)