### PR TITLE
Fixed missed .dashboard-notice h2

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1694,7 +1694,7 @@
   .org-teams-list .team, .subnav-search-context .select-menu-item-icon,
   .ace-github, a.pagehead-nav-item.selected, a.pagehead-nav-item:hover,
   .repo-collection .collection-stat, a.subscribe-feed, header ul.links a:hover,
-  div.container > p, .commits-list-item .commit-author,
+  div.container > p, .commits-list-item .commit-author, .dashboard-notice h2,
   .full-commit .sha-block > .sha, .discussion-item .renamed-was,
   .discussion-item .renamed-is, a.discussion-item-entity,
   span.discussion-item-entity, .table-list-header-toggle .btn-link.selected,


### PR DESCRIPTION
The selector `.dashboard-notice` from [this line of github-dark.css](https://github.com/StylishThemes/GitHub-Dark/blob/ed28c8852ab10bbad1f7b0fb375dbadce52d92e6/github-dark.css#L1693) applying the rule `color: #c0c0c0 !important;`
Had been overpowered by
[this stock stylesheet](https://assets-cdn.github.com/assets/github-6a628757f656425789b747aa37ffe446cad8faaa6e1217ddc024f3969bddbca7.css)
```css
.dashboard-notice h2 {
	margin-top:9px;
	margin-bottom:16px;
	font-size:18px;
	font-weight:normal;
	color:#000
}
```
https://assets-cdn.github.com/assets/github-6a628757f656425789b747aa37ffe446cad8faaa6e1217ddc024f3969bddbca7.css

