### PR TITLE
Star color in repo list is gray instead of bluish.

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -500,6 +500,10 @@
   .discussion-topic-header, .previewable-comment-form .tabnav {
     border-radius: 3px 3px 0 0 !important;
   }
+  /* star count and color in repo lists */
+  .mini-repo-list-item .stars {
+	  color: #777;
+  }
   /* repo labels, private repo lists */
   .repo-label span, .private .repo-list-item, .hook-delivery-guid {
     background: #222 !important;


### PR DESCRIPTION
In the repo list on your user dashboard, the star counts and icon is a blue-ish tinted gray. The repo icon is `#777` and the proximity of the two barely different grays looks a bit strange.

This PR changes the star counts and colors to `#777` which is the same as the repo icons.

Here is a before pic:
<img width="345" alt="screen shot 2017-03-05 at 12 51 07 pm" src="https://cloud.githubusercontent.com/assets/916259/23590741/d49caf48-01a2-11e7-8a60-afe9c1a5f81f.png">

And after:
<img width="327" alt="screen shot 2017-03-05 at 12 52 48 pm" src="https://cloud.githubusercontent.com/assets/916259/23590742/d5d29328-01a2-11e7-8ce3-a1bc8e8cd67e.png">
