### PR TITLE
Change color in GitHub Dark

### DIFF
--- a/themes/src/github/github-dark.css
+++ b/themes/src/github/github-dark.css
@@ -63,7 +63,7 @@
 .pl-mh .pl-en /* markup.heading entity.name */,
 .pl-ms /* meta.separator */ {
   font-weight: bold;
-  color: #264ec5;
+  color: #4c66e2;
 }
 .pl-mq /* markup.quote */ {
   color: #00acac;


### PR DESCRIPTION
The markup headings were too dark.

Closes #500.