### PR TITLE
Zenhub improvements, mostly for dependencies

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2702,6 +2702,7 @@
   }
   /*** ZenHub styling ***/
   .zhc-selection-item:hover, .zhc-selection-item--is-active,
+  .zhc-selection-item.zhc-selection-item--is-active:not(.zhc-selection-item--is-disabled),
   .zh-select-menu-item.navigation-focus, .zh-select-menu-item:hover,
   .zh-tabs__nav-item:hover {
     background: /*[[base-color]]*/ #4183c4 !important;
@@ -2710,6 +2711,10 @@
   }
   .zhc-pipeline-sort-status__clear {
     color: /*[[base-color]]*/ #4183c4 !important;
+  }
+  .zhc-dependency-type-dropdown--is-open .zhc-dependency-type-dropdown__control {
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
   }
   /* background */
   .zhc-pipeline, .zh-epic-creator-top, .zh-epic-creator-nav, input.zhc-icon,
@@ -2741,7 +2746,8 @@
   .zh-epic-creator-progress-bar, .zhc-tooltip-action__content,
   .zh-timeline-comment-header, .zh-issueviewer-title,
   .zh-new-issue-suggester-input-container, .zhc-pr-issue-connector__info,
-  .zhu-tag-default, .zhc-chart-container__header {
+  .zhu-tag-default, .zhc-chart-container__header, .zhc-dependency,
+  .zhc-dependency-banner {
     background: #202020 !important;
     border-color: #484848 !important;
   }
@@ -2749,7 +2755,8 @@
   .zhc-badge--issue-count, .zhc-tooltip-action__item:hover,
   .zh-todolist-completed-separator, .zh-todolist-today-separator,
   .zh-epic-issue-list-item-badge .zh-pipeline-badge, .zh-pipeline-badge-light,
-  .zhc-dropdown-simple-item:hover {
+  .zhc-dropdown-simple-item:hover, .zhc-selection-item, .zhc-progress-bar,
+  .zhc-dependency-type-dropdown__list__item {
     background: #333 !important;
   }
   .zh-epic-creator-tab.selected, .zh-pipeline-badge-light {
@@ -2765,11 +2772,14 @@
   .zhc-readonly-banner {
     background: #182030 !important;
   }
-  .zhc-progress-bar {
-    background: #333 !important;
-  }
   .zhc-progress-bar > .zhc-progress-bar--completed-issues {
     background: #163 !important;
+  }
+  .zhc-selection-item--is-active .zhc-icon--board-light {
+    background-image: url("https://user-images.githubusercontent.com/3282350/27267371-e0aace98-5475-11e7-8b2f-dc774eaf5fd3.png") !important;
+  }
+  .zhc-dependency-type-dropdown__list {
+    background: none !important;
   }
   /* border */
   .zhc-pr-issue-connector__info:after {
@@ -2791,6 +2801,10 @@
   .popover.left .arrow {
     border-left-color: #343434 !important;
   }
+  .zhc-dependency-type-dropdown__control,
+  .zhc-dependency-type-dropdown__list__item {
+    border-color: #484848 !important;
+  }
   /* text */
   .zhc-selection-list__header__text, .zhc-merge-repo-item__content,
   .zhc-repo-item, .zh-todolist-create:hover, .zh-todolist-name,
@@ -2807,6 +2821,16 @@
     opacity: 1 !important;
     -webkit-filter: brightness(2) !important;
             filter: brightness(2) !important;
+  }
+  .zhc-selection-item--is-active .zhc-dependency-issue-selector__issue-item-meta {
+    color: #fff !important;
+  }
+  .zhc-dependency .zhu-text-important, .zhc-dependency-banner,
+  .zhc-dependency-type-dropdown__control, .zhc-dependency-type-dropdown__list {
+    color: #c0c0c0 !important;
+  }
+  .zhc-click-text-item {
+    color: /*[[base-color]]*/ #4183c4 !important;
   }
   /* ZenHub buttons */
   .zhc-toggle-button, .zhc-btn, .zh-todo-issue-dropdown .zh-split-button-icon,

--- a/github-dark.css
+++ b/github-dark.css
@@ -2834,7 +2834,8 @@
   }
   /* ZenHub buttons */
   .zhc-toggle-button, .zhc-btn, .zh-todo-issue-dropdown .zh-split-button-icon,
-  .zhu-blankslate, .zh-tabs__nav-item:not(.zh-tabs__nav-item--active) {
+  .zh-todo-issue-button .zh-split-button-right-side, .zhu-blankslate,
+  .zh-tabs__nav-item:not(.zh-tabs__nav-item--active) {
     background: linear-gradient(#282828, #181818) !important;
     border-color: #383838 !important;
   }


### PR DESCRIPTION
### 1. Styles the Dependency function:

Before:

<img width="769" alt="screen shot 2017-06-18 at 23 23 07" src="https://user-images.githubusercontent.com/3282350/27268379-3098f11c-547d-11e7-9ab9-479472ee07e6.png">

<img width="792" alt="screen shot 2017-06-18 at 23 20 16" src="https://user-images.githubusercontent.com/3282350/27268300-c4754ac6-547c-11e7-8344-619652f0b1e1.png">

<img width="785" alt="screen shot 2017-06-18 at 23 20 00" src="https://user-images.githubusercontent.com/3282350/27268303-caa6f5f2-547c-11e7-8da0-f9acb01ef1e9.png">


After

<img width="762" alt="screen shot 2017-06-18 at 23 23 28" src="https://user-images.githubusercontent.com/3282350/27268382-35ff46c4-547d-11e7-8e40-662059f52f8d.png">

<img width="743" alt="screen shot 2017-06-18 at 23 25 03" src="https://user-images.githubusercontent.com/3282350/27268431-631e7d5a-547d-11e7-972a-587d71b6911f.png">

<img width="715" alt="screen shot 2017-06-18 at 23 13 39" src="https://user-images.githubusercontent.com/3282350/27268313-dba7bac6-547c-11e7-9525-1c260eedf072.png">

### 2. Also styles the to-do dropdown menu button

Before:

<img width="76" alt="screen shot 2017-06-18 at 23 18 34" src="https://user-images.githubusercontent.com/3282350/27268258-7e39d450-547c-11e7-9d80-70876a675632.png">

After:

<img width="86" alt="screen shot 2017-06-18 at 21 49 47" src="https://user-images.githubusercontent.com/3282350/27268245-684d3f10-547c-11e7-9bfe-d96d0660b897.png">

### Notes
- The colored text in the "this issue is blocked by" doesn't actually change between the before and after - that's just me switching from a red theme to a blue theme
- Something strange is happening with https://user-images.githubusercontent.com/3282350/27267371-e0aace98-5475-11e7-8b2f-dc774eaf5fd3.png (<img src="https://user-images.githubusercontent.com/3282350/27267371-e0aace98-5475-11e7-8b2f-dc774eaf5fd3.png">). It should turn that icon in the depency-selector item white when the item is active, but for me in situ it's rendering as black. The documentation asks for attachment links, but it might be best to encode it
- it's possible `.zhc-selection-item--is-active` in line 2704 is made unnecessary by the new necessary `.zhc-selection-item.zhc-selection-item--is-active:not(.zhc-selection-item--is-disabled)` in 2705