### PR TITLE
Support GitHub Enterprise highlight

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2556,6 +2556,7 @@
   /* code and diff line selection */
   pre div[style^="background-color: rgb(248, 238, 199)"],
   .highlight td.blob-code-inner[style^="background-color: rgb(255, 251, 221)"],
+  .highlight td.blob-code-inner[style^="background-color: rgb(248, 238, 199)"],
   .line[style^="background-color: rgb(255, 255, 204)"],
   td.selected-line.blob-num, td.selected-line.blob-code {
     background: rgba(85, 85, 85, .4) !important;


### PR DESCRIPTION
I'm not sure if it's due to the version of GitHub Enterprise I'm using, but code line links don't use the appropriate background-color due to a mismatch in the element-level style being applied (too bad github isn't doing this with a css class!).  This patch resolves that issue.