### PR TITLE
Don't list lockfiles in .gitignore, remove them before commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,6 @@ build.json
 *.build.min.css
 themes/build/
 
-# lockfiles
-package-lock.json
-yarn.lock
-
 # debug files from npm/yarn
 npm-debug.log
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "grunt-exec": "^3.0.0",
     "grunt-string-replace": "^1.3.1",
     "grunt-wrap": "^0.3.1",
+    "husky": "^0.14.3",
     "parse5": "^3.0.2",
     "perfectionist": "^2.4.0",
     "postcss": "^6.0.8",
+    "remove-lockfiles": "^0.1.0",
     "semver": "^5.4.1",
     "stylelint": "^8.0.0",
     "stylelint-config-standard": "^17.0.0"
@@ -29,6 +31,7 @@
     "stylelint": "stylelint --silent --color -- github-dark.css themes/**/*.css",
     "eclint": "eclint check github-dark.css *.js tools/*.js index.html images/*.svg",
     "perfectionist": "perfectionist",
+    "precommit": "remove-lockfiles",
     "test": "npm run eslint && npm run stylelint && npm run eclint"
   }
 }


### PR DESCRIPTION
**What**:
Integrate [remove-lockfiles](https://github.com/luftywiranda13/remove-lockfiles)

**Why**:
Currently this project ignores lockfiles (package-lock.json & yarn.lock). **This can lead to harder debugging process** because contributors might be locked to different versions of deps

**How**:
- Install `remove-lockfiles` then integrate it in `precommit`
- Remove lockfiles from `.gitignore`

**How did I test this?**
- There are tests in `remove-lockfiles` repo
- Also tested in this project by installing deps using `yarn` and `npm`. Lockfiles were generated but not included in commits.
- `remove-lockfiles` not only unstages but also removes the lockfiles before commits