### PR TITLE
Avoid styling github.community

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2,7 +2,7 @@
   /* Repository: https://github.com/StylishThemes/GitHub-Dark    */
   /* Userstyle:  http://userstyles.org/styles/37035              */
   /* License:    https://creativecommons.org/licenses/by-sa/4.0/ */
-@-moz-document regexp("^https?://((gist|guides|help|raw|status|developer)\\.)?github\\.com((?!generated_pages/preview).)*$"), domain("githubusercontent.com"), domain("graphql-explorer.githubapp.com") {
+@-moz-document regexp("^https?://((gist|guides|help|raw|status|developer)\\.)?github\\.com/((?!generated_pages/preview).)*$"), domain("githubusercontent.com"), domain("graphql-explorer.githubapp.com") {
   /* begin auto-generated rules - use tools/generate.js to generate them */
   /* auto-generated rule for "background-color: #2cbe4e" */
   .State--green, .block-diff-added, .block-diff-neutral,


### PR DESCRIPTION
GitHub now has a community forum on https://github.community/.
The regex was a bit too eager to style things outside of github.com.