### PR TITLE
fixed link to K&R style

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you don't know CSS very well and have found a missing style, please include a
 ## GitHub Dark Style Guide
 
 * Use the provided `.editorconfig` file with your code editor. Don't know what that is? Then check out http://editorconfig.org/.
-* Limit to the [K&R Style](http://en.wikipedia.org/wiki/1_true_brace_style#K.26R_style), and **2 SPACE INDENTATION** (no tabs, and not more, and not less than 2 spaces).
+* Limit to the [K&R Style](https://en.wikipedia.org/wiki/Indentation_style#K.26R), and **2 SPACE INDENTATION** (no tabs, and not more, and not less than 2 spaces).
 
   * K&R Example:
     ```css


### PR DESCRIPTION
Old link. Redirected to `Indentation_style` and `#K.26R_style` is now just `#K.26R`.