### PR TITLE
Fix color of repo description text

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -515,7 +515,8 @@
   .repository-meta .edit-repository-meta label, .access-token .token-description,
   .access-token .credential-authorization-menu .status-heading, .token-scope,
   .shelf-dismiss .close-button:hover, .team-listing .is-open .expand-nested-team,
-  .workspace-tree [aria-selected], .subheader-nav .nav-item.selected {
+  .workspace-tree [aria-selected], .subheader-nav .nav-item.selected,
+  .repository-meta-content [itemprop="about"] {
     color: #c0c0c0 !important;
   }
   /* auto-generated rule for "color: #444d56" */


### PR DESCRIPTION
The short repository descriptions have had dark text for a while now. In some cases, the text was white but more often than not, it was dark and unreadable.