### PR TITLE
polls: improve contrast

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2185,7 +2185,7 @@
   /* invert network graph; gh-polls (https://github.com/apex/gh-polls) */
   div#network.network > div > canvas, a[href*="api.gh-polls.com"] img,
   img[data-canonical-src*="prod/timeseries/"], img[alt="FOSSA Status"] {
-    filter: invert(90%) hue-rotate(180deg) contrast(50%) !important;
+    filter: invert(90%) hue-rotate(180deg) contrast(70%) !important;
   }
   /* invert problematic emoji */
   /* images */

--- a/github-dark.css
+++ b/github-dark.css
@@ -2185,7 +2185,7 @@
   /* invert network graph; gh-polls (https://github.com/apex/gh-polls) */
   div#network.network > div > canvas, a[href*="api.gh-polls.com"] img,
   img[data-canonical-src*="prod/timeseries/"], img[alt="FOSSA Status"] {
-    filter: invert(90%) hue-rotate(180deg) contrast(70%) !important;
+    filter: invert(90%) hue-rotate(180deg) contrast(90%) !important;
   }
   /* invert problematic emoji */
   /* images */

--- a/github-dark.css
+++ b/github-dark.css
@@ -2185,7 +2185,7 @@
   /* invert network graph; gh-polls (https://github.com/apex/gh-polls) */
   div#network.network > div > canvas, a[href*="api.gh-polls.com"] img,
   img[data-canonical-src*="prod/timeseries/"], img[alt="FOSSA Status"] {
-    filter: invert(90%) hue-rotate(180deg) !important;
+    filter: invert(90%) hue-rotate(180deg) contrast(50%) !important;
   }
   /* invert problematic emoji */
   /* images */


### PR DESCRIPTION
before
![polls-b](https://user-images.githubusercontent.com/31389848/39971266-057b26e6-56f0-11e8-9d50-6e99843c625d.PNG)

after (contrast 50%)
![polls-a](https://user-images.githubusercontent.com/31389848/39971267-0ce76174-56f0-11e8-97e9-ca9582dfbf49.PNG)

I think maybe a contrast of 70% feels better here tbh.

after (contrast 70%)
![polls-a-70](https://user-images.githubusercontent.com/31389848/39971287-6b2488fc-56f0-11e8-9c1d-55e0678069bf.PNG)

let me add that instead

OK 90% is better is less subtle contrast in bg but slightly more than without contrast.

 #contrast 90%
![polls-a-90](https://user-images.githubusercontent.com/31389848/39972248-08542b2a-5703-11e8-97d8-f2ff9903b11d.PNG)

![poll-u](https://user-images.githubusercontent.com/31389848/39972261-68097a52-5703-11e8-8618-abd8880b7fd8.PNG)

