### PR TITLE
kbd: increase inset bottom box-shadow by 1px fixes #629

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2064,7 +2064,7 @@
     box-shadow: inset 0 1px 0 #343434 !important;
   }
   kbd {
-    box-shadow: inset 0 -1px 0 #343434 !important;
+    box-shadow: inset 0 -2px 0 #343434 !important;
   }
   /* semi-transparent */
   .context-loader.large-format-loader, #graphs .loader, .org-header,


### PR DESCRIPTION
@xt0rted can rest easily now :smiley_cat: 

2px
![capture](https://user-images.githubusercontent.com/31389848/41247474-f9616b28-6da5-11e8-9436-caf61eb68be3.PNG)

default 1px
![capture](https://user-images.githubusercontent.com/31389848/41248099-d8a48936-6da7-11e8-80b5-4461ce8c65f4.PNG)

Are you happy with that?

Another alternative is making it lighter instead, but IDK, lets see what comments come of this.

default css points to 1px
<!-- The following code block was formatted with Prettier. If this is not desired, please change this comment to `prettier-github disable`. A copy of your original code block is included below in case you want to restore it.
Learn more about Prettier GitHub at https://github.com/jgierer12/prettier-github

.markdown-body kbd {
	display: inline-block;
	padding: 3px 5px;
	font-size: 11px;
	line-height: 10px;
	color: #444d56;
	vertical-align: middle;
	background-color: #fafbfc;
	border: solid 1px #c6cbd1;
	border-bottom-color: #959da5;
	border-radius: 3px;
	box-shadow: inset 0 -1px 0 #959da5;
}

-->
```css
.markdown-body kbd {
  display: inline-block;
  padding: 3px 5px;
  font-size: 11px;
  line-height: 10px;
  color: #444d56;
  vertical-align: middle;
  background-color: #fafbfc;
  border: solid 1px #c6cbd1;
  border-bottom-color: #959da5;
  border-radius: 3px;
  box-shadow: inset 0 -1px 0 #959da5;
}
```


