### PR TITLE
fixes: part fix hovering text/icon for #644

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2661,7 +2661,9 @@
   .topic-tag-action .remove-topic-button:hover,
   .discussion-item-changes-marker.is-unread .discussion-item-icon,
   .toc-select .navigation-focus *, .suggester li[aria-selected="true"],
-  .suggester li[aria-selected="true"] small {
+  .suggester li[aria-selected="true"] small,
+  .jump-to-suggestions-path:hover .jump-to-octicon,
+  .jump-to-suggestions-path:hover .jump-to-suggestion-name {
     color: #efefef !important;
   }
   .btn, a.btn, .btn.btn-primary, .button.primary, .minibutton.primary,


### PR DESCRIPTION
before/after
![hover](https://user-images.githubusercontent.com/31389848/41604425-246916ea-73d7-11e8-9699-17952408e9a4.gif)

If I could figure out the knockout issue Ill add that as local fix