### PR TITLE
issues: really fix #647 and prevent jump to from shifting to left.

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1884,7 +1884,7 @@
     max-width: 250px !important;
   }
   .jump-to-suggestions [aria-selected="true"] .jump-to-suggestion-name.css-truncate-target {
-    max-width: 50% !important;
+    width: 50% !important;
   }
   /* tooltip */
   .octotip {

--- a/github-dark.css
+++ b/github-dark.css
@@ -1884,7 +1884,7 @@
     max-width: 250px !important;
   }
   .jump-to-suggestions [aria-selected="true"] .jump-to-suggestion-name.css-truncate-target {
-    width: 50% !important;
+    width: 41% !important;
   }
   /* tooltip */
   .octotip {


### PR DESCRIPTION
max-width is wrong here see
![capture](https://user-images.githubusercontent.com/31389848/41625385-939d272a-7410-11e8-9d7a-3d9e4eac8f56.PNG)

width is correct and jump-to is in right position.
![capture](https://user-images.githubusercontent.com/31389848/41625434-c01ebe8a-7410-11e8-8ed5-65fd050f7c13.PNG)

@Mottie did you not see my fix in userCSS? lol

@xt0rted see what I mean? Its bad enough that long titles are cut off but as is you get to see even less 
max, pff, like Pepsi, gimme Coke.
