### PR TITLE
fix: prereceive feedback banner fixes #658

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -3222,7 +3222,7 @@
   /* yellow text */
   /* .bg-pending might be a GitHub bug as it sets the fg */
   .text-pending, a.text-pending, .text-renamed, a.text-renamed, .bg-pending,
-  a.bg-pending, .prereceive-feedback pre {
+  a.bg-pending {
     color: #cb4 !important;
   }
   /* yellow border (travis) */
@@ -4117,7 +4117,7 @@
   .graphiql-ide.signed-out:after {
     background: #000 !important;
   }
-  .graphiql-container {
+  .graphiql-container, .prereceive-feedback-heading {
     color: #ddd !important;
   }
   .graphiql-container .docExplorerShow:before {

--- a/github-dark.css
+++ b/github-dark.css
@@ -3194,7 +3194,7 @@
   .compare-pr-placeholder, .compare-cutoff, .diff-cutoff, .flash.flash-warn,
   .flash-global.flash-warn, .markdown-body li.added.moved, .repo-private-label,
   .gist-secret-label, .label-private, .stale-files-tab, .signed-out-comment,
-  .warning, .commits-list-item em, .unsupported-browser {
+  .warning, .commits-list-item em, .unsupported-browser, .prereceive-feedback {
     background: rgba(51, 34, 17, .4) !important;
     border: 1px solid #542 !important;
     color: #ddd !important;
@@ -3222,7 +3222,7 @@
   /* yellow text */
   /* .bg-pending might be a GitHub bug as it sets the fg */
   .text-pending, a.text-pending, .text-renamed, a.text-renamed, .bg-pending,
-  a.bg-pending {
+  a.bg-pending, .prereceive-feedback pre {
     color: #cb4 !important;
   }
   /* yellow border (travis) */


### PR DESCRIPTION
![capture](https://user-images.githubusercontent.com/31389848/41822912-c9cfcc80-77ee-11e8-80e3-717789aa7830.PNG)

The pre clearly will come into use with some more specific msg later, see issue ticket for before fix looks.

this styles the banner and pre since the .prereceive-feedback-heading` is already handled by autogenerate.
https://github.com/StylishThemes/GitHub-Dark/blob/8313559707f85deb49829f033eecc0f5e554fb76/github-dark.css#L990