### PR TITLE
re-tweak: issue #603 and move to grey bg fixes #665

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2016,7 +2016,7 @@
   .Box-row--focus-gray.navigation-focus, .team-listing .is-open.root-team,
   .Box-row--hover-gray:hover, table.files tr[aria-selected="true"] td,
   .label-select-menu .select-menu-item[aria-selected="true"],
-  .label-select-menu .select-menu-item.navigation-focus {
+  .label-select-menu .select-menu-item.navigation-focus, .review-comment:target {
     background: #242424 !important;
   }
   #main, .capped-box, .unread_count, #browser table th,
@@ -3176,7 +3176,7 @@
   .state-indicator.renamed, .discussion-topic .branch-status.status-pending,
   .discussion-item-review.is-pending .file-header,
   .discussion-item-review.is-pending .comment-form-head.tabnav,
-  .stale-session-flash.flash.flash-warn, .review-comment:target {
+  .stale-session-flash.flash.flash-warn {
     background-color: #261d08 !important;
     border-color: #542 !important;
     color: #ddd !important;


### PR DESCRIPTION
I think the blue color may look more natural than the brown, which just looks out-of-place.

Im sure there must be some very good reason to why GitHub-Dark chose to address issues caused by refined GitHub well off default design choices that are not part of default GitHub stylesheet.
But since that was the case, I propose a more suitable color that is actually present around comments, like the blue.

Idk if a border is needed and definitely can be tested as soon as this is triggered.