### PR TITLE
issues: tree view fixes re: #679

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -3447,10 +3447,11 @@
   }
   /* network members */
   .network-tree {
-    width: 26px !important;
+    width: 19px !important;
     height: 0 !important;
     padding-top: 26px !important;
     background-repeat: no-repeat !important;
+    background-position: -2px center !important;
   }
   .network-tree[src$="t.png"] {
     background-image: url("data:image/gif;base64,R0lGODlhFAAaAIAAAMzMzP///yH5BAEAAAEALAAAAAAUABoAAAIkjI+pG8APY5O0uorfzRzt3n1g5pSTOTJiSq1s5L6ajMW0YgcFADs=") !important;


### PR DESCRIPTION
Test these out @tambry 

gif shows initially zoom at 100% and each full scroll into oposite direction increases 10% zoom up to 130% zoom with no gaps.

Browser FF 61.0
 
zoom 100% initial scroll to bottom
zoom 110% scroll to top
zoom 120% scroll to bottom
zoom 130% scroll to top

the gif is 15MB (squeezed from original 37MB) so download it...

https://www.dropbox.com/s/5pypt47ab9albi6/treeview.gif?dl=1
