### PR TITLE
issues: sticky hdr covers selected line fixes #598

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1299,7 +1299,7 @@
     .pull-request-tab-content .diff-view .file-header {
       position: sticky !important;
       position: -webkit-sticky !important;
-      top: 39px !important;
+      top: 35px !important;
       z-index: 6 !important;
     }
     .pull-request-tab-content .file-header {
@@ -1307,7 +1307,7 @@
     }
     .pull-request-tab-content .diff-view .file-actions,
     .pull-request-tab-content .diff-view .file-info {
-      margin-top: -2px !important;
+      margin-top: -1px !important;
     }
   }
   /* User time line firsts */

--- a/github-dark.css
+++ b/github-dark.css
@@ -1295,12 +1295,20 @@
     position: -webkit-sticky !important;
     top: 8px !important;
   }
-  /* copied from Refined GitHub extension */
-  .pull-request-tab-content .diff-view .file-header {
-    position: sticky !important;
-    position: -webkit-sticky !important;
-    top: 39px !important;
-    z-index: 6 !important;
+  @supports (position: sticky) or (position: -webkit-sticky) {
+    .pull-request-tab-content .diff-view .file-header {
+      position: sticky !important;
+      position: -webkit-sticky !important;
+      top: 39px !important;
+      z-index: 6 !important;
+    }
+    .pull-request-tab-content .file-header {
+      height: 39px !important;
+    }
+    .pull-request-tab-content .diff-view .file-actions,
+    .pull-request-tab-content .diff-view .file-info {
+      margin-top: -2px !important;
+    }
   }
   /* User time line firsts */
   img[src$="profile-joined-github.png"] {

--- a/github-dark.css
+++ b/github-dark.css
@@ -1299,11 +1299,12 @@
     .pull-request-tab-content .diff-view .file-header {
       position: sticky !important;
       position: -webkit-sticky !important;
-      top: 35px !important;
+      top: 40px !important;
       z-index: 6 !important;
     }
     .pull-request-tab-content .file-header {
-      height: 39px !important;
+      height: 32px !important;
+      padding: 1px 10px !important;
     }
     .pull-request-tab-content .diff-view .file-actions,
     .pull-request-tab-content .diff-view .file-info {


### PR DESCRIPTION
This uncovers just enough of the selected line to be a good candidate to fix #598 

Im using this now locally and it works reliably enough to warrant this PR.

Re: non-default  sticky header styles/scripts,

If there is a problem with those, it is beyond the scope of this issue and this fix, IMO and they need to be addressed separately and should not be a blocker for anything like this.

@maxrothman since you were the person to report the issue maybe this would be a good enough solution rather than none or having to do js workaround scripts.

![oauth-octicon-x](https://user-images.githubusercontent.com/31389848/42731228-c3985d60-8800-11e8-8865-72213c0e5536.gif)
