### PR TITLE
fix contrib-legend #ebedf0 style

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2251,8 +2251,8 @@
   .contribution-activity-listing .progress-bar[style*="c6e48b"], .facebox-close {
     opacity: .75 !important;
   }
-  /* contribution calendar - regular colors */
-  .calendar-graph rect[fill="#ebedf0"], .contrib-legend li[style*="#eee"] {
+  /* contribution calendar/legend - regular colors */
+  .calendar-graph rect[fill="#ebedf0"], .contrib-legend li[style*="#ebedf0"] {
     background-color: #222 !important;
     fill: #222 !important;
   }


### PR DESCRIPTION
I imagine at some stage GiHub updated this color from `#eee` to `#ebedf0`which resulted in this break.

![contrib-legend](https://user-images.githubusercontent.com/31389848/42731383-0a323108-8804-11e8-89bb-4fa5f868f979.gif)
