### PR TITLE
issues: fix dragover box-shadow and set to base-color instead of green

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1225,6 +1225,9 @@
     box-shadow: inset 0 1px 2px rgba(0, 0, 0, .075), 0 0 2px /*[[base-color]]*/ #4183c4 !important;
     outline-color: /*[[base-color]]*/ #4183c4 !important;
   }
+  .dragover textarea, .dragover .drag-and-drop {
+    box-shadow: 0 0 1px 1px /*[[base-color]]*/ #4183c4 !important;
+  }
   /* inputs */
   select, input:not(.btn-link), textarea {
     -moz-appearance: none !important;


### PR DESCRIPTION
fixes the broken box-shadow and re-colors to base-color.

![dragover](https://user-images.githubusercontent.com/31389848/42732552-a790a4d6-881b-11e8-8ff2-f7b383aae15f.gif)
