### PR TITLE
Pull Request: Add specific support for refined-github stickied headers

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1295,13 +1295,6 @@
     position: -webkit-sticky !important;
     top: 8px !important;
   }
-  /* copied from Refined GitHub extension */
-  .pull-request-tab-content .diff-view .file-header {
-    position: sticky !important;
-    position: -webkit-sticky !important;
-    top: 39px !important;
-    z-index: 6 !important;
-  }
   /* User time line firsts */
   img[src$="profile-joined-github.png"] {
     padding-bottom: 20px !important;
@@ -1313,15 +1306,22 @@
   .pr-toolbar.is-stuck {
     pointer-events: none !important;
   }
-  .pr-toolbar.is-stuck+.pr-toolbar-shadow {
+  .pr-toolbar.is-stuck + .pr-toolbar-shadow {
     background: #181818 !important;
     top: 0 !important;
     height: 40px !important;
     border-bottom: 1px solid #343434 !important;
   }
+  .refined-github .pr-toolbar.is-stuck + .pr-toolbar-shadow {
+    height: 60px !important;
+  }
   .diffbar {
     padding-top: 10px !important;
     padding-bottom: 10px !important;
+  }
+  .refined-github .diffbar {
+    padding-top: 20px !important;
+    padding-bottom: 20px !important;
   }
   .is-stuck .diffbar {
     background: #181818 !important;


### PR DESCRIPTION
Another approach to https://github.com/StylishThemes/GitHub-Dark/issues/598. This basically removes our opinionated stickying and supports the 60px high stickied header of `refined-github` specifically. I think this is a good compromise, if users want stickied filenames, they can install that extension.

Example with refined-github:

<img width="1272" alt="screenshot 2018-07-19 at 20 32 23" src="https://user-images.githubusercontent.com/115237/42962852-e1033e2a-8b92-11e8-8e28-6d62802fe052.png">

And without:

<img width="1235" alt="screenshot 2018-07-19 at 20 33 09" src="https://user-images.githubusercontent.com/115237/42962906-0694435a-8b93-11e8-9cac-c34328bbabd6.png">

@the-j0k3r
