### PR TITLE
fix: dropdown-menu arrow color and border

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -3504,6 +3504,15 @@
   .new-discussion-timeline .composer .timeline-comment:after {
     border-right-color: #222 !important;
   }
+  #com .dropdown-menu:after {
+    border: 9px solid;
+    border-color: transparent transparent #181818;
+    content: " ";
+    left: 50%;
+    top: -17px;
+    position: absolute;
+    margin-left: -9px;
+  }
   .dropdown-menu-w:before {
     border-bottom-color: transparent !important;
   }


### PR DESCRIPTION
Actually this just fixes the color the border is doing my nut in.

https://help.github.com/ the version dropdown menu

see comment in https://github.com/StylishThemes/GitHub-Dark/commit/17c086a6d0b0c491dc6d034f4304c23afc6aac89#commitcomment-29918150

before (this is autogenerated atm)
![before](https://user-images.githubusercontent.com/31389848/43528458-f4db9b32-95a0-11e8-8362-a1a0f57dd204.PNG)

after
![after](https://user-images.githubusercontent.com/31389848/43528457-f241a236-95a0-11e8-955c-46d09984dcfc.PNG)

How to add a line around that arrow is the question.

