### PR TITLE
Add styling for scrollbar corner of code editor

### DIFF
--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -3901,7 +3901,7 @@
     max-height: 10px !important;
     background: #1d1d1d !important;
   }
-  ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner {
+  ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner, .CodeMirror-scrollbar-filler {
     background: #1d1d1d !important;
   }
   ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
Previously, the scrollbar corner was not addressed by the CSS and appeared pure white. No the colour matches the thumbs.

Here's a comparison of the changes:
Before
![before](https://user-images.githubusercontent.com/31934788/46171665-cd601100-c2be-11e8-8b0b-af02e82aec4c.png)

After
![after](https://user-images.githubusercontent.com/31934788/46171674-d355f200-c2be-11e8-8dc6-f2303e799877.png)

Do let me know if anything else is required!
