### PR TITLE
Use light text for ZenHub Issue Card Titles

### DIFF
--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -4221,7 +4221,8 @@
   }
   .zhc-dependency .zhu-text-important, .zhc-dependency-banner,
   .zhc-dependency-type-dropdown__control, .zhc-dependency-type-dropdown__list,
-  .zhc-selection-item--is-disabled, .zhc-issue-card__heading__main {
+  .zhc-selection-item--is-disabled, .zhc-issue-card__heading__main,
+  .zhc-issue-card__issue-title {
     color: #c0c0c0 !important;
   }
   .zhc-click-text-item {


### PR DESCRIPTION
Make ZenHub issue card titles readable when using dark theme.

Before: 
![image](https://user-images.githubusercontent.com/4054771/46308402-64062980-c56e-11e8-9f8d-131f4c3fa904.png)


After:
![image](https://user-images.githubusercontent.com/4054771/46308237-f954ee00-c56d-11e8-9524-ae9b1ed4f0c7.png)
