### PR TITLE
Darken text from e2e2e2 to c0c0c0

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2861,7 +2861,7 @@
   .select-menu-item[aria-selected="true"],
   .select-menu-item[aria-selected="true"].selected, .btn-danger:hover,
   .btn-danger:active, .btn-danger.selected, [open] > .btn-danger {
-    color: #e2e2e2 !important;
+    color: #c0c0c0 !important;
   }
   pre, body, a.social-count, span.social-count, #languages a.bar, .lineoption p,
   a.blog-title, table.notifications th, .usagestats dl dt.numbers,
@@ -3709,7 +3709,7 @@
   }
   /* custom hover highlight in code and diffs */
   .highlight tr:hover .blob-num:not(.non-expandable) {
-    color: #e2e2e2 !important;
+    color: #c0c0c0 !important;
   }
   .diff-table tr:hover > pre,
   .highlight:not(.lines) tr:not(.inline-comments):hover td.selected-line.blob-num:not(.line-age),
@@ -4167,7 +4167,7 @@
   }
   a.notifications-dropdown-see-all:hover, .top-nav .dropdown-menu a:hover {
     background: /*[[base-color]]*/ #4183c4 !important;
-    color: #e2e2e2 !important;
+    color: #c0c0c0 !important;
   }
   .notifications-dropdown-arrow {
     border-bottom-color: #333 !important;


### PR DESCRIPTION
This matches most of the other text present in the theme.

Before:

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/2101409/46359076-45ab3700-c61d-11e8-9dd0-2a3a1a53fdcb.png">

After:

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/2101409/46359136-6c696d80-c61d-11e8-878f-fa8c792ed88b.png">

Looks subtle here, makes a big difference when you have a wall of it like on the issues page there.