### PR TITLE
Add css to properly colorize directory icon

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -3036,7 +3036,7 @@
   .dashboard-notice .dismiss:hover, .text-gray, td.icon .octicon-file-text,
   td.icon .octicon-file-symlink-file, .UnderlineNav-item, .project-header-link,
   button.project-header-link, td.icon, .project-pane-close, .facebox-close,
-  .tree-browser-result mark {
+  .tree-browser-result mark, td.icon .octicon-file-directory {
     color: #949494 !important;
   }
   .vcard-detail .octicon, .member-badge .octicon,


### PR DESCRIPTION
Noticed the directory icons weren't being properly styled, due to a
missing style. They are now styled to match file and symlink icons.

See the before and after shots.

<img width="236" alt="before" src="https://user-images.githubusercontent.com/16705/46577809-26f1cb00-c9a4-11e8-835c-dad65583305b.png">
<img width="227" alt="after" src="https://user-images.githubusercontent.com/16705/46577810-29542500-c9a4-11e8-9ebf-0d2e18229ec3.png">

It's not clear to me if I've patched this in the proper way based on some other commits so if I need to adjust this somewhere else please let me know. Thanks.
