### PR TITLE
Add new zenhub styles

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -3260,7 +3260,8 @@
   .compare-pr-placeholder, .compare-cutoff, .diff-cutoff, .flash.flash-warn,
   .flash-global.flash-warn, .markdown-body li.added.moved, .repo-private-label,
   .gist-secret-label, .label-private, .stale-files-tab, .signed-out-comment,
-  .warning, .commits-list-item em, .unsupported-browser, .prereceive-feedback {
+  .warning, .commits-list-item em, .unsupported-browser, .prereceive-feedback,
+  .zhc-banner {
     background: rgba(51, 34, 17, .4) !important;
     border: 1px solid #542 !important;
     color: #ddd !important;
@@ -3910,7 +3911,10 @@
   .zhc-board-loading__message, .zhc-pipeline--is-collapsed, .zhc-issue-card,
   .zh-todo-item-placeholder, .zh-timeline-comment, .zh-epic-creator-tab,
   .zh-issueviewer-content, .zhc-chart-container, tr.zhc-item-table__row--closed,
-  .zhc-sidebar__container, .zhc-sidebar__container__inner {
+  .zhc-sidebar__container, .zhc-sidebar__container__inner,
+  .zhc-workspace-switcher, .zhc-workspace-switcher__header, .zhc-workspace-form,
+  .zhc-workspace-form__footer__actions, .zhc-confirmation-modal,
+  .zhc-issue-card__connected-pull-request {
     background: #111 !important;
     border-color: #484848 !important;
   }
@@ -3924,7 +3928,8 @@
   .zhc-dependency, .zhc-dependency-banner, .zhc-selection-list__body,
   .zhc-selection-item, .zhc-issues-list-item, .zhc-tag, .zhc-item-table,
   .zhc-item-table__row, .zhc-menu-container__modal-content,
-  .zhc-chart-info__wrapper, .zh-collapse-control:hover {
+  .zhc-chart-info__wrapper, .zh-collapse-control:hover, .zhc-epic-list,
+  .zhc-collapsible-control {
     background: #181818 !important;
     border-color: #484848 !important;
   }
@@ -3943,7 +3948,8 @@
     border-color: #484848 !important;
   }
   .zhc-sidebar-nav-item--is-active, .zhc-sidebar-nav-item:hover,
-  .zhc-sidebar-profile__toggle:hover {
+  .zhc-sidebar-profile__toggle:hover, .zhc-workspace-header:hover,
+  .zhc-workspace-switcher-item:hover {
     background: #202020 !important;
   }
   .zhc-merge-repo-item:hover, .zhc-merge-repo-item--is-active,
@@ -3956,8 +3962,38 @@
   .zhc-dependency-header__status__controls .zhc-btn:hover,
   .zhc-sidebar-nav-item__action:hover, .zhc-sidebar-nav-item__action--is-active,
   .zhc-reports-nav-item__sub-item:hover, .zhc-sidebar-profile__item:hover,
-  .zhc-sidebar-divider__bar {
+  .zhc-sidebar-divider__bar, .zhc-btn--default:hover,
+  .zhc-btn--primary-bordered:hover, .zhc-btn--secondary-bordered:hover,
+  .zhc-btn--secondary:hover, .zhc-issue-card__actions__btn:hover,
+  .zhc-btn:hover .zhc-btn--text-secondary:hover {
     background: #333 !important;
+  }
+  .zhc-workspace-switcher-item .zhc-btn,
+  .zhc-workspace-switcher-item .zhc-btn--show-on-hover,
+  .zhc-current-workspace__controls .zhc-btn, .zhc-btn--secondary,
+  .zhc-btn--text-secondary {
+    background: #111 !important;
+    border-color: #383838 !important;
+  }
+  .zhc-workspace-switcher-item, .zhc-workspace-form-item {
+    border-color: transparent transparent #383838 !important;
+  }
+  .zhc-workspace-switcher-item:hover,
+  .zhc-workspace-switcher__header .zhc-org-dropdown:hover,
+  .zhc-workspace-form__close:hover, .zhc-workspace-switcher__x:hover,
+  .zhc-workspace-switcher__close:hover {
+    background: #333 !important;
+    border-color: #383838 !important;
+  }
+  .zhc-btn--text-secondary:hover {
+    color: #484848 !important;
+  }
+  .zhc-workspace-form-item__control {
+    border-color: transparent !important;
+  }
+  .zhc-workspace-switcher__header, .zhc-workspace-form__header {
+    background: #111 !important;
+    box-shadow: #111 0 0 4px 4px !important;
   }
   .zh-epic-creator-tab.selected, .zh-pipeline-badge-light {
     border-top-color: /*[[base-color]]*/ #4183c4 !important;
@@ -3995,7 +4031,8 @@
   .zhc-chart-container__footer, .zhc-chart-legend__labels, .zhc-issues-list,
   .zhc-tabs__nav-item, .zhc-menu-bar-item--search-bar, .zhc-menu-bar-item,
   .zh-collapse-manager-container--isExpanded .discussion-item:last-child,
-  .zhc-selection-list__header, .zhc-sidebar-profile__item:hover {
+  .zhc-selection-list__header, .zhc-sidebar-profile__item:hover,
+  .zhc-collapsible-control:hover {
     border-color: #343434 !important;
   }
   .zhc-tooltip-action__content:before, .zhc-pr-issue-connector__info:before {
@@ -4039,7 +4076,9 @@
   .zhc-dependency .zhu-text-important, .zhc-dependency-banner,
   .zhc-dependency-type-dropdown__control, .zhc-dependency-type-dropdown__list,
   .zhc-selection-item--is-disabled, .zhc-issue-card__heading__main,
-  .zhc-issue-card__issue-title {
+  .zhc-issue-card__issue-title, .zhc-epic-list,
+  .zhc-issue-card__connected-pull-request, .zhu-text-important,
+  .zhc-epic-pipeline-item__title {
     color: #c0c0c0 !important;
   }
   .zhc-click-text-item {
@@ -4050,7 +4089,8 @@
   .zh-todo-issue-dropdown .zh-split-button-icon, .zhc-btn--tint,
   .zh-split-button-right-side, .zhu-blankslate, .zh-reports .zhc-btn,
   .zhc-dependency-header__status__controls .zhc-btn,
-  .zhc-issue-selector .zhc-btn {
+  .zhc-issue-selector .zhc-btn, .zhc-btn--default, .zhc-btn--primary-bordered,
+  .zhc-issue-card__actions__btn {
     background: linear-gradient(#282828, #181818) !important;
     border-color: #383838 !important;
   }


### PR DESCRIPTION
Heavy user of ZenHub, and loving GitHub-Dark, but a lot of ZenHub's new features required tweaking since they defaulted white.

This is mostly what I've been using personally that I recently cleaned up a bit. I tried to stick with only colours/styles that already existed. However since there were quite a few new big ZenHub features, quite a few new classes had to be added.

The 4 main areas that were changed are:
- A few new button styles
- `Epics` panel
- `Workspace` Switcher/Editor modal styles
- New confirmation modal