### PR TITLE
Fix Zenbub nav tab icon colors

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -4265,9 +4265,14 @@
     height: 14px !important;
   }
   /* invert image */
-  .zh-icon-circled-bolt, .zh-icon-bolt, .zh-octicon-x,
-  a.zh-topbar-item.selected .zh-icon-zenhub {
+  .zh-icon-circled-bolt, .zh-icon-bolt, .zh-octicon-x {
     filter: invert(40%) brightness(120%) !important;
+  }
+  a.zh-topbar-item.selected .zh-icon-zenhub {
+    filter: invert(40%) brightness(169%) !important;
+  }
+  a.zh-topbar-item .zh-icon-zenhub {
+    filter: brightness(64%) !important;
   }
   .zhc-icon:not([class$="-red"]):not([class$="-white"]):not([class$="-light"]):not([class$="-purple"]),
   .zhc-board-loading, .zhc-board-loading__message, .zh-octicon-list-unordered,


### PR DESCRIPTION
Currently the Zenhub tab's icon is dim when the Zenhub tab is selected, and bright otherwise (ignore my custom body background color in the screenshots):

<img width="262" alt="screen shot 2018-10-28 at 15 07 49" src="https://user-images.githubusercontent.com/3282350/47620734-14ab0e80-dac4-11e8-97aa-a6e93d748609.png">
<img width="254" alt="screen shot 2018-10-28 at 15 07 59" src="https://user-images.githubusercontent.com/3282350/47620736-14ab0e80-dac4-11e8-90fc-3f97fddd80b7.png">

With this PR, the Zenhub tab's icon is bright icon when the Zenhub tab is selected, and dim otherwise:

<img width="248" alt="screen shot 2018-10-28 at 15 11 20" src="https://user-images.githubusercontent.com/3282350/47620754-48863400-dac4-11e8-8ab8-d351a9b651f0.png">
<img width="254" alt="screen shot 2018-10-28 at 15 10 29" src="https://user-images.githubusercontent.com/3282350/47620755-48863400-dac4-11e8-9d65-f25335a5601a.png">

The new colors as close to the "correct" colors as is possible using `filter` in Chrome 70, even with fractional `brightness`: `#b9babc` for bright, `#757678` for dim (compared to the native tab icons' `#bababa` and `#757575`)