### PR TITLE
[wip] Initial styling of the new actions editor

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -5317,11 +5317,6 @@
       box-shadow: 0 0 0 .2em rgba(65, 131, 196, .4) !important;
       box-shadow: 0 0 0 .2em rgba(/*[[base-color-rgb]]*/, .4) !important;
   }
-  .form-control:focus {
-    border-color: /*[[base-color]]*/ !important;
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, .075), 0 0 2px /*[[base-color]]*/ !important;
-    outline-color: /*[[base-color]]*/ !important;
-  }
   /* These rules need to be auto generated since the class names are dynamic */
   /* rgb(239, 241, 245) */
   .jsx-434284492 {

--- a/github-dark.css
+++ b/github-dark.css
@@ -5247,7 +5247,6 @@
   }
   /* Literal.Number.Integer.Long */
 }
-
 @-moz-document domain("github.com") {
   /* ui when there are no workflows setup */
   .deployments-timeline-item + div:not(.deployments-timeline-item) {
@@ -5271,7 +5270,6 @@
     background: #181818 !important;
   }
 }
-
 @-moz-document domain("launch-editor.github.com") {
   body {
     background: #181818 !important;

--- a/github-dark.css
+++ b/github-dark.css
@@ -5247,3 +5247,94 @@
   }
   /* Literal.Number.Integer.Long */
 }
+
+@-moz-document domain("github.com") {
+  /* ui when there are no workflows setup */
+  .deployments-timeline-item + div:not(.deployments-timeline-item) {
+    background-image: linear-gradient( rgba(28, 28, 28, 0), rgba(28, 28, 28, 1)) !important;
+  }
+  [style*="background-color: #e1e4e8"] {
+    background-color: #8e8e8e !important;
+  }
+  [style*="color: #e1e4e8"] {
+    color: #8e8e8e !important;
+  }
+  /**
+   * this is the same form as when you're committing from the site
+   * this means there's a small arrow on the left (which points at
+   * the user's avatar) and this ends up showing in the dropdown too
+   */
+  .file-commit-form .dropdown-menu .commit-form:after {
+    content: none !important;
+  }
+  .file-commit-form .commit-form {
+    background: #181818 !important;
+  }
+}
+
+@-moz-document domain("launch-editor.github.com") {
+  body {
+    background: #181818 !important;
+  }
+  .editor-node[style*="background-color: rgb(68, 77, 85)"] {
+    background: #343434 !important;
+  }
+  .editor-node {
+    background: #1c1c1c !important;
+  }
+  .blankslate-box {
+    background: #242424 !important;
+  }
+  .overlay {
+    background: rgba(27, 31, 35, .5) !important;
+  }
+  .blankslate-box, .editor-node, .editor-node > div {
+    border-color: #484848 !important;
+  }
+  .input, .output {
+    background-image: none !important;
+    background-color: #484848 !important;
+  }
+  .input:before, .output:before {
+    background: transparent !important;
+  }
+  .circle.live:after {
+    background-color: /*[[base-color]]*/ !important;
+  }
+  .arrow-icon-container {
+    color: /*[[base-color]]*/ !important;
+  }
+  [stroke="#959da5"] {
+    stroke: #484848 !important;
+  }
+  [stroke="#2188ff"] {
+    stroke: /*[[base-color]]*/ !important;
+  }
+  .blankslate-box.is-hovering,
+  .editor-node[style*="box-shadow: rgba(3, 102, 214, 0.3)"] {
+      border-color: /*[[base-color]]*/ !important;
+      box-shadow: 0 0 0 .2em rgba(65, 131, 196, .4) !important;
+      box-shadow: 0 0 0 .2em rgba(/*[[base-color-rgb]]*/, .4) !important;
+  }
+  .svg-icon > svg {
+    color: currentColor !important;
+  }
+  input.form-control:focus {
+    border-color: /*[[base-color]]*/ !important;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, .075), 0 0 2px /*[[base-color]]*/ !important;
+    outline-color: /*[[base-color]]*/ !important;
+  }
+  /* These rules need to be auto generated since the class names are dynamic */
+  /* rgb(239, 241, 245) */
+  .jsx-434284492 {
+    background: #202020 !important;
+  }
+  /* removes the background color from the dot when creating a new action */
+  svg + .jsx-434284492 {
+    background: transparent !important;
+  }
+  /* rgb(21, 133, 255) */
+  .jsx-3726811500 {
+    background: /*[[base-color]]*/ !important;
+  }
+}

--- a/github-dark.css
+++ b/github-dark.css
@@ -3264,6 +3264,9 @@
   .delete-topic-button {
     color: inherit !important;
   }
+  .svg-icon svg {
+    color: currentColor !important;
+  }
   /* Alerts and activity, remove background gradient */
   .metabox .editable-text:hover, #inbox .list .item .title span,
   .Subhead.border-bottom-0 {
@@ -5313,9 +5316,6 @@
       border-color: /*[[base-color]]*/ !important;
       box-shadow: 0 0 0 .2em rgba(65, 131, 196, .4) !important;
       box-shadow: 0 0 0 .2em rgba(/*[[base-color-rgb]]*/, .4) !important;
-  }
-  .svg-icon > svg {
-    color: currentColor !important;
   }
   .form-control:focus {
     border-color: /*[[base-color]]*/ !important;

--- a/github-dark.css
+++ b/github-dark.css
@@ -5253,7 +5253,7 @@
 @-moz-document domain("github.com") {
   /* ui when there are no workflows setup */
   .deployments-timeline-item + div:not(.deployments-timeline-item) {
-    background-image: linear-gradient( rgba(28, 28, 28, 0), rgba(28, 28, 28, 1)) !important;
+    background-image: linear-gradient(rgba(28, 28, 28, 0), rgba(28, 28, 28, 1)) !important;
   }
   [style*="background-color: #e1e4e8"] {
     background-color: #8e8e8e !important;

--- a/github-dark.css
+++ b/github-dark.css
@@ -5300,20 +5300,20 @@
     background: transparent !important;
   }
   .circle.live:after {
-    background-color: /*[[base-color]]*/ !important;
+    background-color: /*[[base-color]]*/ #4f8cc9 !important;
   }
   .arrow-icon-container {
-    color: /*[[base-color]]*/ !important;
+    color: /*[[base-color]]*/ #4f8cc9 !important;
   }
   [stroke="#959da5"] {
     stroke: #484848 !important;
   }
   [stroke="#2188ff"] {
-    stroke: /*[[base-color]]*/ !important;
+    stroke: /*[[base-color]]*/ #4f8cc9 !important;
   }
   .blankslate-box.is-hovering,
   .editor-node[style*="box-shadow: rgba(3, 102, 214, 0.3)"] {
-      border-color: /*[[base-color]]*/ !important;
+      border-color: /*[[base-color]]*/ #4f8cc9 !important;
       box-shadow: 0 0 0 .2em rgba(65, 131, 196, .4) !important;
       box-shadow: 0 0 0 .2em rgba(/*[[base-color-rgb]]*/, .4) !important;
   }
@@ -5328,6 +5328,6 @@
   }
   /* rgb(21, 133, 255) */
   .jsx-3726811500 {
-    background: /*[[base-color]]*/ !important;
+    background: /*[[base-color]]*/ #4f8cc9 !important;
   }
 }

--- a/github-dark.css
+++ b/github-dark.css
@@ -5319,7 +5319,7 @@
   .svg-icon > svg {
     color: currentColor !important;
   }
-  input.form-control:focus {
+  .form-control:focus {
     border-color: /*[[base-color]]*/ !important;
     box-shadow: inset 0 1px 2px rgba(0, 0, 0, .075), 0 0 2px /*[[base-color]]*/ !important;
     outline-color: /*[[base-color]]*/ !important;


### PR DESCRIPTION
I figured it was time to send in a PR for some feedback. I don't plan for this to be merged as-is, just looking to see if the rules look good and how we're going to handle integrating it into the rest of the style.

1. The comments are just to help keep track of what's what while working on this.
2. Everything is split out into its own sections to make it easier to review and work on.
    1. I don't think these will work with the current build script, when I run `npx grunt usercss` I'm not seeing them in the output.
4. They're using React for this part of the site so there's inline styles and auto-generated class names (`.jsx-*`) which may change between releases. I've tried to keep their usage to as few as possible for this reason. I'm also trying to get in touch with someone working on this to see if they can add in some descriptive class names to help us out.

Here's some previews of what it looks like in case you don't have access to this yet.

The `Edit new file` and `Preview` tabs run off `github.com` and are fully styled, it's just the `Visual editor` tab that needs styling.

![image](https://user-images.githubusercontent.com/831974/50196508-637d6380-0311-11e9-9bd4-2845a8cdfc8c.png)

![image](https://user-images.githubusercontent.com/831974/50196529-755f0680-0311-11e9-8448-fb1e0c81d7ec.png)

![image](https://user-images.githubusercontent.com/831974/50196584-ab03ef80-0311-11e9-8971-0a7a60ed54dd.png)

![image](https://user-images.githubusercontent.com/831974/50196492-53fe1a80-0311-11e9-943b-9f0ee438b19f.png)
