### PR TITLE
Remove unneeded width style from user timeline header

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1441,10 +1441,6 @@
     height: 2.5em;
     pointer-events: all !important;
   }
-  /* User profile: Make the border not cross into the years buttons */
-  .profile-timeline-month-heading:after {
-    width: calc(100% - 94px) !important;
-  }
   .comment-reactions button.btn-link.user-has-reacted {
     background-color: rgba(79, 140, 201, .2) !important;
     background-color: rgba(/*[[base-color-rgb]]*/, .2) !important;


### PR DESCRIPTION
PRing this to get some feedback. From what I can tell removing this rule doesn't effect the user profile timeline. Maybe there's something I'm missing but it seems like it's safe to remove now.