### PR TITLE
remove sticky header fixes #818 #612 closes #730 #772

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1390,32 +1390,6 @@
     position: -webkit-sticky !important;
     top: 8px !important;
   }
-  @supports (position: sticky) or (position: -webkit-sticky) {
-    .pull-request-tab-content .diff-view .file-header {
-      position: sticky !important;
-      position: -webkit-sticky !important;
-      top: 40px !important;
-      z-index: 6 !important;
-    }
-    .pull-request-tab-content .file-header {
-      padding: 1px 10px !important;
-    }
-    .pull-request-tab-content .diff-view .file-actions,
-    .pull-request-tab-content .diff-view .file-info {
-      margin-top: -1px !important;
-    }
-  /* below element is queried from GitHub's js for the scroll offset */
-  /* see https://github.com/StylishThemes/GitHub-Dark/issues/598 */
-    .js-sticky-offset-scroll {
-      height: 72px !important;
-    }
-    .gh-header-sticky.is-stuck .sticky-content .mt-3 {
-      margin: 5px !important;
-    }
-    .gh-header .gh-header-sticky.is-stuck + .gh-header-shadow {
-      height: 40px !important;
-    }
-  }
   /* User time line firsts */
   img[src$="profile-joined-github.png"] {
     padding-bottom: 20px !important;


### PR DESCRIPTION
This is grief we dont need as part of GHD.

Be gone.