### PR TITLE
Add generate rule for text-blue-mktg

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -824,6 +824,12 @@
   .illflow-blue .illflow-item .illflow-item-heading, .MarketingBody-lead a:hover {
     color: /*[[base-color]]*/ #4f8cc9 !important;
   }
+  /* auto-generated rule for "color: #1277eb" */
+  .text-blue-mktg, .link-mktg, .btn-outline-mktg,
+  .casestudy-link:hover .casestudy-title, .MarketingBody blockquote,
+  .MarketingBody-lead a {
+    color: /*[[base-color]]*/ #4f8cc9 !important;
+  }
   /* auto-generated rule for "color: #586069" */
   .btn .Counter, .form-checkbox .note, .hfields .form-group dt label, .note,
   .drag-and-drop, .drag-and-drop-error-info, h2.account, p.explain,

--- a/tools/generate.js
+++ b/tools/generate.js
@@ -124,6 +124,7 @@ const mappings = {
 
   // needs to be after #333 for .btn vs .btn-outline
   "color: #0366d6": "color: /*[[base-color]]*/ #4f8cc9",
+  "color: #1277eb": "color: /*[[base-color]]*/ #4f8cc9",
   // needs to be after #0366d3 for .btn-link vs .text-gray
   "color: #586069": "color: #949494",
   // needs to be after #0366d3 for .btn-link vs .text-gray-dark


### PR DESCRIPTION
PRing for some feedback. This fixes the blue links on the [new pricing page](https://github.com/pricing), but seems to break some of them elsewhere such as on https://github.com/features. The issue is they're using `box-shadow` on `:hover` which is being overridden in another rule. Any ideas on what we should do to handle these?