### PR TITLE
Adjusting  lock and repo suggestion name color

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1674,10 +1674,6 @@
     background: #222 !important;
     color: #777 !important;
   }
-  /*Repo name Suggesiton color*/
-  .reponame-suggestion {
-    color: #539c2a !important;
-  } 
   .private .mini-repo-list-item .repo-icon {
     color: #777 !important;
   }
@@ -3502,7 +3498,8 @@
   .signed-commit-badge.verified:hover, .Label--outline-green {
     border-color: #6cc644 !important;
   }
-  .signed-commit-verified-label, .signed-commit-badge.verified {
+  .signed-commit-verified-label, .signed-commit-badge.verified,
+  .reponame-suggestion {
     color: #55a532 !important;
   }
   /* Green text */

--- a/github-dark.css
+++ b/github-dark.css
@@ -3449,7 +3449,8 @@
   .text-pending, .text-renamed, .bg-pending {
     color: #cb4 !important;
   }
-  .page-new-repo .octicon-lock {
+  .page-new-repo .octicon-lock,
+  .private a svg {
     color: #651 !important;
   }
   /* yellow border (travis) */

--- a/github-dark.css
+++ b/github-dark.css
@@ -1674,14 +1674,9 @@
     background: #222 !important;
     color: #777 !important;
   }
-  /*Create private repo Lock color*/
-  .page-new-repo .octicon-lock {
-    color: #cb4 !important;
-  }
   /*Repo name Suggesiton color*/
   .reponame-suggestion {
     color: #539c2a !important;
-    cursor: pointer;
   } 
   .private .mini-repo-list-item .repo-icon {
     color: #777 !important;
@@ -3473,6 +3468,10 @@
   .Label--outline.bg-yellow-light,
   .review-comment .pending-batched-suggestion-label {
     background: #302808 !important;
+  }
+  /* Yellow private repo lock */
+  .page-new-repo .octicon-lock {
+    color: #cb4 !important;
   }
   /* green */
   /* labels */

--- a/github-dark.css
+++ b/github-dark.css
@@ -3446,8 +3446,7 @@
   }
   /* yellow text */
   /* .bg-pending might be a GitHub bug as it sets the fg */
-  .text-pending, .text-renamed, .bg-pending, .page-new-repo .octicon-lock,
-  .private a svg {
+  .text-pending, .text-renamed, .bg-pending, .page-new-repo .octicon-lock {
     color: #cb4 !important;
   }
   /* yellow border (travis) */

--- a/github-dark.css
+++ b/github-dark.css
@@ -3453,6 +3453,9 @@
   .text-pending, .text-renamed, .bg-pending {
     color: #cb4 !important;
   }
+  .page-new-repo .octicon-lock {
+    color: #651 !important;
+  }
   /* yellow border (travis) */
   .branch-action-state-unknown .branch-action-body,
   .branch-action-state-unknown .branch-status,
@@ -3468,10 +3471,6 @@
   .Label--outline.bg-yellow-light,
   .review-comment .pending-batched-suggestion-label {
     background: #302808 !important;
-  }
-  /* Yellow private repo lock */
-  .page-new-repo .octicon-lock {
-    color: #cb4 !important;
   }
   /* green */
   /* labels */

--- a/github-dark.css
+++ b/github-dark.css
@@ -1674,6 +1674,15 @@
     background: #222 !important;
     color: #777 !important;
   }
+  /*Create private repo Lock color*/
+  .page-new-repo .octicon-lock {
+    color: #cb4 !important;
+  }
+  /*Repo name Suggesiton color*/
+  .reponame-suggestion {
+    color: #539c2a !important;
+    cursor: pointer;
+  } 
   .private .mini-repo-list-item .repo-icon {
     color: #777 !important;
   }

--- a/github-dark.css
+++ b/github-dark.css
@@ -3446,12 +3446,9 @@
   }
   /* yellow text */
   /* .bg-pending might be a GitHub bug as it sets the fg */
-  .text-pending, .text-renamed, .bg-pending {
-    color: #cb4 !important;
-  }
-  .page-new-repo .octicon-lock,
+  .text-pending, .text-renamed, .bg-pending, .page-new-repo .octicon-lock,
   .private a svg {
-    color: #651 !important;
+    color: #cb4 !important;
   }
   /* yellow border (travis) */
   .branch-action-state-unknown .branch-action-body,


### PR DESCRIPTION
Adjusting lock color when creating a private repo, and repo suggestion name color to be more visible ( yeah nobody cares about suggestion names but still :p )
Before : 
![beforee](https://user-images.githubusercontent.com/43283622/50993211-ef784a80-14cd-11e9-902e-c6fc571904af.PNG)

After : 
![afterr](https://user-images.githubusercontent.com/43283622/50993220-f56e2b80-14cd-11e9-8153-3107fd92c318.PNG)
