### PR TITLE
fix: typos in documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ There are a number of ways to get involved with the development of this GitHub D
 ## How to Report Style issues
 
 ### I don't know CSS
-If you don't know CSS very well and have found a missing style, please include as much as possible of following information when opening an issue:
+If you don't know CSS very well and have found a missing style, please include as much as possible of the following information when opening an issue:
 
 * Screenshot of the problem; include the element(s) in the console if at all possible
   * To select an element, target it with your mouse then right-click and choose "Inspect Element"

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Thank you for reporting an issue. Please make sure that your style is up to
-date and you checked the recent commits that your issue wasn't recently
+date and you checked the recent commits to ensure that your issue wasn't recently
 addressed. To update:
 
 Make sure to first update DIRECTLY from the usercss at 
@@ -9,7 +9,7 @@ if using the GitHub-Dark script, use the "Force Update Style" button, then
 force refresh the web page (Windows: Ctrl+F5; MacOS: Apple+R or Command+R;
 Linux: F5).
 
-If the issue persists, please help us identifying the cause by providing these
+If the issue persists, please help us in identifying the cause by providing these
 details:
 -->
 
@@ -19,8 +19,8 @@ details:
 
 * **HTML of the section where the issue occurs**:
 
-<!-- You can get the HTML by right click on the element, look for the
-     highlighted node in the DevTools, right click it and select
+<!-- You can get the HTML by right-clicking on the element, looking for the
+     highlighted node in the DevTools, right-clicking it and selecting
      Copy -> Outer HTML -->
 
 ````html

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Install [Stylus](https://add0n.com/stylus.html) for either [Firefox](https://add
 
 ## Notes
 
-- If you're using a custom domain for GitHub Enterprise, be sure to include it though a `@-moz-document` rule (Firefox) or add it to the `Applies to` section in (Chrome).
+- If you're using a custom domain for GitHub Enterprise, be sure to include it through a `@-moz-document` rule (Firefox) or add it to the `Applies to` section in (Chrome).
 
 ## Contributions
 


### PR DESCRIPTION
Fixed a few spelling and grammatical errors in the following documentation files: 
- .github/CONTRIBUTING.md
- .github/ISSUE_TEMPLATE.md
- README.md