### PR TITLE
Add Overlay-Scrollbars to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Install [Stylus](https://add0n.com/stylus.html) for either [Firefox](https://add
 ⚙️ [GitHub-Community-Dark](https://github.com/StylishThemes/GitHub-Community-Dark)<br>
 ⚙️ [GitHub-Compact-Feed](https://github.com/StylishThemes/GitHub-Compact-Feed)<br>
 ⚙️ [GitHub-Feed-Icons](https://github.com/StylishThemes/GitHub-Feed-Icons)<br>
+⚙️ [Overlay-Scrollbars](https://github.com/StylishThemes/Overlay-Scrollbars)<br>
 
 ## Supported GitHub Addons
 


### PR DESCRIPTION
I haven't seen any reference to the split Github Overlay Scrollbars repo in the Readme. Seems like it should belong here.