### PR TITLE
Fix usercss generator so it supports multiple document rules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,7 +165,7 @@ module.exports = function(grunt) {
     replacement: config.tab
   }, {
     // remove default syntax themes AND closing bracket
-    pattern: /(\s+\/\* grunt build - remove start \*\/)(.*)(\s+\/\* grunt build - remove end \*\/)$/sm,
+    pattern: /\s+\/\* grunt build - remove start \*\/.*\s+\/\* grunt build - remove end \*\/$/sm,
     replacement: ""
   }, {
     // add selected theme
@@ -199,7 +199,7 @@ module.exports = function(grunt) {
     replacement: "/*[[tab-size]]*/"
   }, {
     // remove default syntax theme AND closing bracket
-    pattern: /(\s+\/\* grunt build - remove start \*\/)(.*)(\s+\/\* grunt build - remove end \*\/)$/sm,
+    pattern: /\s+\/\* grunt build - remove start \*\/.*\s+\/\* grunt build - remove end \*\/$/sm,
     replacement: ""
   }];
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,7 +165,7 @@ module.exports = function(grunt) {
     replacement: config.tab
   }, {
     // remove default syntax themes AND closing bracket
-    pattern: /\s+\/\* grunt build - remove to end of file(.*(\n|\r))+\}$/m,
+    pattern: /(\s+\/\* grunt build - remove start \*\/)(.*)(\s+\/\* grunt build - remove end \*\/)$/sm,
     replacement: ""
   }, {
     // add selected theme
@@ -199,7 +199,7 @@ module.exports = function(grunt) {
     replacement: "/*[[tab-size]]*/"
   }, {
     // remove default syntax theme AND closing bracket
-    pattern: /\s+\/\* grunt build - remove to end of file(.*(\n|\r))+\}$/m,
+    pattern: /(\s+\/\* grunt build - remove start \*\/)(.*)(\s+\/\* grunt build - remove end \*\/)$/sm,
     replacement: ""
   }];
 
@@ -339,7 +339,7 @@ module.exports = function(grunt) {
       mozrule: {
         files: {"<%= config.buildFile %>" : "<%= config.buildFile %>"},
         options: {
-          wrapper: ["<%= config.prefix %>", "}\n"]
+          wrapper: ["<%= config.prefix %>", ""]
         }
       }
     }

--- a/github-dark.css
+++ b/github-dark.css
@@ -4446,7 +4446,7 @@
   /*[[syntax-theme]]*/
   /*[[syntax-codemirror]]*/
   /*[[syntax-jupyter]]*/
-  /* grunt build - remove to end of file */
+  /* grunt build - remove start */
   /* Syntax Theme - Twilight */
   .highlight,
   .CodeMirror {
@@ -5175,6 +5175,7 @@
     color: #099 !important;
   }
   /* Literal.Number.Integer.Long */
+  /* grunt build - remove end */
 }
 @-moz-document domain("zuora.com") {
   body, label, .popup {

--- a/github-dark.css
+++ b/github-dark.css
@@ -5178,6 +5178,7 @@
   /* grunt build - remove end */
 }
 @-moz-document domain("zuora.com") {
+  /* Styles the payment form iframe */
   body, label, .popup {
     background: transparent !important;
     color: #ddd !important;

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -4641,6 +4641,7 @@
   /*[[syntax-jupyter]]*/
 }
 @-moz-document domain("zuora.com") {
+  /* Styles the payment form iframe */
   body, label, .popup {
     background: transparent !important;
     color: #ddd !important;

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -4639,5 +4639,23 @@
   /*[[syntax-theme]]*/
   /*[[syntax-codemirror]]*/
   /*[[syntax-jupyter]]*/
-
 }
+@-moz-document domain("zuora.com") {
+  body, label, .popup {
+    background: transparent !important;
+    color: #ddd !important;
+  }
+  input, select {
+    background: #111 !important;
+    color: #ddd !important;
+    border-color: #484848 !important;
+  }
+  .btn-submit {
+    background: linear-gradient(#407045, #305530) !important;
+    border-color: #083 !important;
+  }
+  .btn-submit:hover {
+    background: linear-gradient(#508055, #407045) !important;
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "css": "2.2.4",
     "css-mediaquery": "0.1.2",
-    "eslint": "5.13.0",
-    "eslint-config-silverwind": "2.0.14",
+    "eslint": "5.14.1",
+    "eslint-config-silverwind": "2.1.0",
     "fs-extra": "7.0.1",
     "grunt": "1.0.3",
     "grunt-contrib-clean": "2.0.0",
@@ -30,7 +30,7 @@
     "semver": "5.6.0",
     "stylelint": "9.10.1",
     "stylelint-config-standard": "18.2.0",
-    "updates": "7.1.0",
+    "updates": "7.1.1",
     "url-toolkit": "2.1.6",
     "ver": "4.0.1"
   }


### PR DESCRIPTION
This fixes the usercss generator so it supports multiple `@-moz-document` rules which is currently being used for the payment iframes, and will also be used to style some of the actions editor.

The second commit shows what was missing by not supporting this.