### PR TITLE
Add another class to increase specificity of octotree

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -5874,7 +5874,7 @@
   .octotree-github-sidebar a.octotree-toggle:hover,
   .octotree-github-sidebar a.octotree-opts:hover .settings:before,
   .octotree-github-sidebar a.octotree-opts.selected:hover .settings:before,
-  .octotree-sidebar.octotree-github-sidebar .octotree-views .octotree-tree-view .jstree-anchor,
+  .octotree-sidebar.octotree-github-sidebar .octotree-views .octotree-tree-view .jstree .jstree-anchor,
   .octotree-github-sidebar a.octotree-toggle:not(.octotree-loading):hover,
   .octotree-sidebar.octotree-github-sidebar .octotree-views .octotree-view,
   .octotree-sidebar.octotree-github-sidebar .octotree-toggle > span,


### PR DESCRIPTION
Currently, `.octotree-sidebar.octotree-github-sidebar .octotree-views .octotree-tree-view .jstree-anchor` has the same CSS specificity as the one from octotree itself, as both are defined using `!important` and with the same number of classes. Thus, which style is selected is not deterministic (GitHub-Dark is selected in Chrome, original Octotree is selected in Firefox).

I notice that all `jstree-anchor` are stored inside `jstree`, thus adding `.jstree` selector will increase specificity (since there are higher number of classes than the original Octotree) and be selected.

This is the issue with Firefox noted in #911