### PR TITLE
Mobile commit header fixes

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -3266,7 +3266,7 @@
   }
   .gisttabs a:not(.selected), .gisttabs a:not(.selected):hover,
   .timeline-comment-wrapper, .avatar-stack .avatar, .full-commit .commit-meta,
-  .breadcrumb, .tabs > a, .header .divider-vertical, .about-menu-link {
+  .tabs > a, .header .divider-vertical, .about-menu-link {
     border-color: transparent !important;
   }
   /* darken border */

--- a/github-dark.css
+++ b/github-dark.css
@@ -4345,7 +4345,7 @@
   .RecentBranches-item, .commit-ref .user {
     color: #6d7c9c !important;
   }
-  .github-jobs-promotion p, .octotip, .full-commit.commit,
+  .github-jobs-promotion p, .octotip, .full-commit.commit:not(.mobile),
   .bootcamp .bootcamp-body, .bootcamp h1, .owners-notice, .new-user-avatar-cta,
   .full-commit .browse-button, .commit-ref, .branch-name, .file-history-tease,
   .feature-banner, .recently-touched-branches,


### PR DESCRIPTION
Wanted to PR this to see if someone sees any issues with the change or if it may break something I'm unaware of.

The generated rules are styling `background-color` and `border-color` so this change follows that. It also removes `!important` which was another recent change.

Switching to style just the color removes the left & right border that's showing on the blue section, and the removal of the transparent selector is because it's hiding the border between the breadcrumb section and the blue section. On desktop the breadcrumb section doesn't show on this page, but it does when viewing a [single file](https://github.com/StylishThemes/GitHub-Dark/blob/master/package.json) (the `GitHub-Dark / package.json` text) but there's no border there on desktop.

This is the page used for the screenshots https://github.com/StylishThemes/GitHub-Dark/commit/7cf20aa6ce2815af23bd466be49bcdca2edb773d.

**Before**

![github com_StylishThemes_GitHub-Dark_commit_7cf20aa6ce2815af23bd466be49bcdca2edb773d(Pixel 2)](https://user-images.githubusercontent.com/831974/56663511-42889e80-6674-11e9-96aa-fe9b9cd34585.png)

**After**

![github com_StylishThemes_GitHub-Dark_commit_7cf20aa6ce2815af23bd466be49bcdca2edb773d(Pixel 2) (1)](https://user-images.githubusercontent.com/831974/56663514-44526200-6674-11e9-99b4-d66238ba9323.png)
