### PR TITLE
Fixed repo private lock icon color.

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2535,7 +2535,7 @@
   /* auto-generated rule for "fill: #dbab09" */
   .graph-canvas .alert-label--low, .repo-private-icon, .donut-chart > .expected,
   .donut-chart > .in_progress, .donut-chart > .pending, .donut-chart > .queued {
-    fill: #cb4;
+    fill: #cb4 !importent;
   }
   /* auto-generated rule for "border-bottom-color: #fffbdd" */
   .form-group.warn .warning:after, .form-group.warn .warning::after,


### PR DESCRIPTION
Added !important to force the style rule to be applied to the classes assigned to it.