### PR TITLE
Added regex matching github.company.com

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1,7 +1,7 @@
 /*! Github Dark v1.21.46 (2019-04-29) */
 /*! Repository: https://github.com/StylishThemes/GitHub-Dark    */
 /*! License:    https://creativecommons.org/licenses/by-sa/4.0/ */
-@-moz-document regexp("^https?://((gist|guides|help|launch-editor|raw|resources|status|developer)\\.)?github\\.com/((?!generated_pages/preview).)*$"), domain("githubusercontent.com"), domain("graphql-explorer.githubapp.com") {
+@-moz-document regexp("^https?://((gist|guides|help|launch-editor|raw|resources|status|developer)\\.)?github\\.*.*\\.com/((?!generated_pages/preview).)*$"), domain("githubusercontent.com"), domain("graphql-explorer.githubapp.com") {
   button {
     color: #b5b5b5;
   }

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -197,7 +197,7 @@
   } EOT;
 }
 ==/UserStyle== */
-@-moz-document regexp("^https?://((gist|guides|help|launch-editor|raw|resources|status|developer)\\.)?github\\.com/((?!generated_pages/preview).)*$"), domain("githubusercontent.com"), domain("graphql-explorer.githubapp.com") {
+@-moz-document regexp("^https?://((gist|guides|help|launch-editor|raw|resources|status|developer)\\.)?github\\.*.*\\.com/((?!generated_pages/preview).)*$"), domain("githubusercontent.com"), domain("graphql-explorer.githubapp.com") {
 /*! Github Dark v1.21.46 (2019-04-29) */
 /*! Repository: https://github.com/StylishThemes/GitHub-Dark    */
 /*! License:    https://creativecommons.org/licenses/by-sa/4.0/ */


### PR DESCRIPTION
Updated github-dark to match my company's enterprise domain which looks like "github.company.com"

I'm not sure how to provide evidence that this works other than my word, I found this style and when I installed it initially did not work for my company's external domain, after this little bit of regex addition it started to work on both normal GitHub and GitHub Enterprise.

Sorry If I didn't conform to any of the contributing steps, it seems they may have been more directed at creating new styles or something?