### PR TITLE
Setup npm scripts for common tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "node": ">=10"
   },
   "scripts": {
-    "test": "npx grunt lint"
+    "clean": "grunt clean",
+    "generate": "grunt generate",
+    "test": "grunt lint",
+    "usercss": "grunt usercss"
   },
   "devDependencies": {
     "css": "2.2.4",


### PR DESCRIPTION
It's my understanding that you don't need to use `npx` when calling Grunt from an npm script. I don't have Grunt installed globally, it's only installed as a dependency in this repo, and using these scripts works perfectly fine for me.

I'm PRing to see what the build server says and for some feedback from @StylishThemes/github to see if anyone has any issues running these.

Task | Command
-- | --
clean | `npm run clean`
generate | `npm run generate`
test | `npm run test` or `npm test`
usercss | `npm run usercss`

We could add more of these in for doing releases, I just wasn't sure what one(s) we'd want right now.