### PR TITLE
Add graphql explorer to the generator

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -30,6 +30,25 @@
     color: #181818;
   }
   /* begin auto-generated rules - use tools/generate.js to generate them */
+  /* auto-generated rule for "background: white" */
+  .graphiql-container .docExplorerWrap, .graphiql-container .historyPaneWrap,
+  .graphiql-container .doc-explorer, body.status .es-menu,
+  body.zh_logged_in .DayPicker--vertical-scrollable .DayPicker__week-header {
+    background: #181818;
+  }
+  /* auto-generated rule for "background-color: white" */
+  body.status ._3c5eahGieigDTmRHO-d7l3 [class^="Content__ChildWrapper"] > [class^="Content"],
+  body.status ._2NFgh0Z6tkGorUToiId47k [class^="Content__ChildWrapper"] > [class^="Content"],
+  body.status ._3c5eahGieigDTmRHO-d7l3 .status-dropdown__option::before,
+  body.status ._2NFgh0Z6tkGorUToiId47k .status-dropdown__option::before,
+  body.status ._2wOD5aJH3F-IjQcHIh8Udc, body.status ._2dv0LNfUzjAAPh-wPACjXb,
+  body.status .cpt-toggle .bubble,
+  body.status .layout-content.status.status-full-history .uptime-calendar #uptime-tooltip,
+  body.status .layout-content.status.status-full-history .uptime-calendar #uptime-tooltip #box-arrow,
+  body.status .layout-content.status.status-full-history .uptime-calendar #uptime-tooltip .tooltip-box,
+  body.status #uptime-tooltip .tooltip-box {
+    background-color: #181818;
+  }
   /* auto-generated rule for "background: #fff" */
   image-crop .handle:before, .pagination a, .pagination em, .pagination span,
   .AvatarStack-body, .blankslate code, .markdown-body .csv-data .blob-num,
@@ -47,6 +66,8 @@
   table.files, .qr-code-table .white, .signup-plan-card:hover,
   .gist-quicksearch-results, .nav-desktop-productDropdown,
   .nav-desktop-langDropdown, header #search-results-container,
+  .graphiql-container .execute-options, .graphiql-container .toolbar-menu-items,
+  .graphiql-container .toolbar-select-options, .btn-primary .counter,
   html[prefix] .btn-primary .counter, html[prefix] .blankslate code,
   html[prefix] .markdown-body .csv-data .blob-num, html[prefix] .card,
   html[prefix] .pagination a, html[prefix] .pagination em,
@@ -137,7 +158,11 @@
   .orgs-help-item-octicon, .plan-category-tab, .business-sso .business-sso-panel,
   .business-sso .org-sso-panel, .org-sso .business-sso-panel,
   .org-sso .org-sso-panel, .btn-purple .Counter, .ais-SearchBox-input,
-  .form-group .ais-SearchBox-input:focus, html[prefix] .Box,
+  .form-group .ais-SearchBox-input:focus, .btn-outline:hover .counter,
+  .btn-outline:active .counter, .btn-outline.selected .counter,
+  .btn-outline.zeroclipboard-is-hover .counter,
+  .btn-outline.zeroclipboard-is-active .counter, .btn-outline:disabled:hover,
+  .btn-outline.disabled:hover, .avatar-stack .avatar, .card, html[prefix] .Box,
   html[prefix] .btn-outline, html[prefix] .btn-outline.selected .counter,
   html[prefix] .btn-outline.zeroclipboard-is-active .counter,
   html[prefix] .btn-outline.zeroclipboard-is-hover .counter,
@@ -454,9 +479,24 @@
   .checks-index-item:hover, .tree-browser-result[aria-selected=true] {
     background-color: #181818 !important;
   }
+  /* auto-generated rule for "background-color: #ffffff" */
+  .graphiql-container .doc-explorer-contents,
+  .graphiql-container .history-contents, body,
+  body.status .dropdown .dropdown-menu, body.status .modal, body.status .popover,
+  body.status .cpt-tabs:not(.unstyled) li.active a,
+  body.status .layout-content.status.status-api .section .example-container .example-opener .color-secondary,
+  body.status .grouped-items-selector,
+  body.status .layout-content.status.status-full-history .history-nav a.current,
+  body.status #uptime-tooltip .tooltip-box {
+    background-color: #181818;
+  }
   /* auto-generated rule for "background: #ffe" */
   .oauth-org-access-details .oauth-org-item:hover {
     background: #242424;
+  }
+  /* auto-generated rule for "background: #fdfdfd" */
+  .graphiql-container .toolbar-button {
+    background: #1c1c1c;
   }
   /* auto-generated rule for "background-color: #fdfdfd" */
   html[prefix] .headlines li:hover, html[prefix] .sidebar-module h3 a:hover {
@@ -507,7 +547,7 @@
     background-color: #181818 !important;
   }
   /* auto-generated rule for "background: #f8f8f8" */
-  .hljs, html[prefix] .markdown-body .csv-data th,
+  .hljs, .markdown-body .csv-data th, html[prefix] .markdown-body .csv-data th,
   body.zh_logged_in .zh-select-menu-filters, body.zh_logged_in .hljs,
   body.zh_logged_in .zhc-chart-info__wrapper,
   body.zh_logged_in .DateRangePickerInput,
@@ -517,7 +557,8 @@
     background: #202020;
   }
   /* auto-generated rule for "background-color: #f8f8f8" */
-  .manage-repo-access-title, html[prefix] .markdown-body table tr:nth-child(2n),
+  .manage-repo-access-title, .markdown-body table tr:nth-child(2n),
+  html[prefix] .markdown-body table tr:nth-child(2n),
   body.status .component-statuses .component-status-container .component-dropdown-selector.dropdown-open .component-status-display,
   body.status .dropdown .dropdown-menu li:hover,
   body.status .updates-dropdown-container .updates-dropdown .updates-dropdown-nav a,
@@ -933,7 +974,7 @@
     background: #181818;
   }
   /* auto-generated rule for "background-color: #f9f9f9" */
-  .session-authentication, .paypal-container,
+  .session-authentication, .paypal-container, .menu-item:hover,
   html[prefix] .sidebar-module ul ul li,
   html[prefix] .content .sectionbody .dlist dt,
   html[prefix] .content .verseblock-content, html[prefix] .content dl code,
@@ -947,6 +988,7 @@
     background-color: #181818;
   }
   /* auto-generated rule for "background-color: #4183C4" */
+  .hidden-text-expander a:active, .ellipsis-expander:active,
   html[prefix] .ellipsis-expander:active,
   html[prefix] .hidden-text-expander a:active,
   html[prefix] .site-header-nav .dropdown-menu a:hover {
@@ -1037,8 +1079,8 @@
     border-color: transparent !important;
   }
   /* auto-generated rule for "border: 5px solid transparent" */
-  .coupon-label:after, .svg-tip:after, html[prefix] .tooltipped::before,
-  body.zh_logged_in .zh-tooltip:before,
+  .coupon-label:after, .svg-tip:after, .tooltipped::before,
+  html[prefix] .tooltipped::before, body.zh_logged_in .zh-tooltip:before,
   body.zh_logged_in .zhc-tooltip__content::before {
     border-color: transparent;
   }
@@ -1431,6 +1473,19 @@
   .commit-form:before {
     border-right-color: #343434;
   }
+  /* auto-generated rule for "border-top: 1px solid #d6d6d6" */
+  .graphiql-container .doc-explorer-contents,
+  .graphiql-container .history-contents {
+    border-top-color: #343434;
+  }
+  /* auto-generated rule for "border-bottom: 1px solid #d6d6d6" */
+  .graphiql-container .variable-editor-title {
+    border-bottom-color: #343434;
+  }
+  /* auto-generated rule for "border-bottom: 1px solid #d3d6db" */
+  .graphiql-container .search-box {
+    border-bottom-color: #343434;
+  }
   /* auto-generated rule for "border: 1px solid #d1d5da" */
   kbd, .Box, .Box-header, .form-control, .form-select, .menu, .markdown-body kbd,
   .SelectMenu-modal, .boxed-group-inner, .timeline-comment,
@@ -1528,9 +1583,12 @@
   .file, .repository-lang-stats-graph, .manage-repo-access-group,
   .manage-repo-access-teams-group, .theme-selector-thumbnail, .user-key-badge,
   .user-key-email, .user-key-email-unverified, .saved-reply-form,
-  .github-access-banner, html[prefix] .Box, html[prefix] .social-count,
-  html[prefix] .form-control, html[prefix] .form-select,
-  html[prefix] .markdown-body table td, html[prefix] .markdown-body table th,
+  .github-access-banner, .Box, .social-count, .form-control, .form-select,
+  .markdown-body table th, .markdown-body table td,
+  .markdown-body span.frame > span, html[prefix] .Box,
+  html[prefix] .social-count, html[prefix] .form-control,
+  html[prefix] .form-select, html[prefix] .markdown-body table td,
+  html[prefix] .markdown-body table th,
   html[prefix] .markdown-body span.frame > span, html[prefix] .sidebar-module,
   html[prefix] .app-container img, html[prefix] .content ol > li img,
   html[prefix] .content table th, html[prefix] .content table td,
@@ -1559,11 +1617,12 @@
     border-color: #343434 !important;
   }
   /* auto-generated rule for "border-color: #ddd" */
-  html[prefix] .Box-header, html[prefix] .tabnav-tab.selected,
-  body.status input[disabled], body.status select[disabled],
-  body.status textarea[disabled], body.status select[readonly],
-  body.status input[disabled]:hover, body.status select[disabled]:hover,
-  body.status textarea[disabled]:hover, body.status select[readonly]:hover,
+  .Box-header, .tabnav-tab.selected, html[prefix] .Box-header,
+  html[prefix] .tabnav-tab.selected, body.status input[disabled],
+  body.status select[disabled], body.status textarea[disabled],
+  body.status select[readonly], body.status input[disabled]:hover,
+  body.status select[disabled]:hover, body.status textarea[disabled]:hover,
+  body.status select[readonly]:hover,
   body.status .grouped-items-selector.inline .border-color,
   body.status .panel.panel-default,
   body.status .panel.panel-default .panel-heading,
@@ -1571,7 +1630,7 @@
     border-color: #343434;
   }
   /* auto-generated rule for "border-color: #ddd !important" */
-  html[prefix] .border-gray-dark {
+  .border-gray-dark, html[prefix] .border-gray-dark {
     border-color: #343434 !important;
   }
   /* auto-generated rule for "border-top: 1px solid #ddd" */
@@ -1584,8 +1643,8 @@
   }
   /* auto-generated rule for "border-bottom: 1px solid #ddd" */
   .manage-repo-access-title, .notification-center .overview,
-  .two-factor-settings-group, .setup-header, .setup-info-module h2,
-  html[prefix] .rule, html[prefix] hr, html[prefix] .tabnav,
+  .two-factor-settings-group, .setup-header, .setup-info-module h2, hr, .rule,
+  .tabnav, html[prefix] .rule, html[prefix] hr, html[prefix] .tabnav,
   html[prefix] .sub-nav, html[prefix] .libraries-jumbotron,
   body.status .cpt-tabs:not(.unstyled), body[data-render-url] .pdf-page,
   body.zh_logged_in .zh-select-menu-text-filter,
@@ -1606,7 +1665,7 @@
     border-right-color: #343434;
   }
   /* auto-generated rule for "border-bottom: 1px dashed #ddd" */
-  html[prefix] .upload-enabled textarea {
+  .upload-enabled textarea, html[prefix] .upload-enabled textarea {
     border-bottom-color: #343434;
   }
   /* auto-generated rule for "border-left: 4px solid #ddd" */
@@ -1805,13 +1864,14 @@
     border-right-color: #343434;
   }
   /* auto-generated rule for "border: 1px solid #e5e5e5" */
-  .marketing-hero-octicon, .listgroup, html[prefix] .btn-outline,
-  html[prefix] .subnav-item, html[prefix] .blankslate,
-  html[prefix] [class*=btn-outline], html[prefix] .card, html[prefix] .highlight,
-  html[prefix] .example, html[prefix] .menu, html[prefix] .data-table,
-  html[prefix] .sidebar-menu, html[prefix] .pagination a,
-  html[prefix] .pagination em, html[prefix] .pagination > span,
-  body.zh_logged_in .zh-pipeline, body.zh_logged_in .zh-pipeline-issue-content,
+  .marketing-hero-octicon, .listgroup, .btn-outline, .subnav-item, .blankslate,
+  .card, .data-table, html[prefix] .btn-outline, html[prefix] .subnav-item,
+  html[prefix] .blankslate, html[prefix] [class*=btn-outline],
+  html[prefix] .card, html[prefix] .highlight, html[prefix] .example,
+  html[prefix] .menu, html[prefix] .data-table, html[prefix] .sidebar-menu,
+  html[prefix] .pagination a, html[prefix] .pagination em,
+  html[prefix] .pagination > span, body.zh_logged_in .zh-pipeline,
+  body.zh_logged_in .zh-pipeline-issue-content,
   body.zh_logged_in .zh-milestone-dates,
   body.zh_logged_in .zh-reports .stats-container,
   body.zh_logged_in .zh-issue-list .table-list-title,
@@ -1821,12 +1881,14 @@
     border-color: #343434;
   }
   /* auto-generated rule for "border: 1px solid #e5e5e5 !important" */
-  html[prefix] .border {
+  .border, html[prefix] .border {
     border-color: #343434 !important;
   }
   /* auto-generated rule for "border-color: #e5e5e5" */
-  html[prefix] .btn-outline.disabled, html[prefix] .btn-outline.disabled:hover,
-  html[prefix] .btn-outline:disabled, html[prefix] .btn-outline:disabled:hover,
+  .btn-outline:disabled, .btn-outline:disabled:hover, .btn-outline.disabled,
+  .btn-outline.disabled:hover, html[prefix] .btn-outline.disabled,
+  html[prefix] .btn-outline.disabled:hover, html[prefix] .btn-outline:disabled,
+  html[prefix] .btn-outline:disabled:hover,
   html[prefix] [class*=btn-outline].disabled,
   html[prefix] [class*=btn-outline].disabled:hover,
   html[prefix] [class*=btn-outline]:disabled,
@@ -1842,20 +1904,21 @@
   .is-bad-file .repo-file-upload-errors, .is-empty .repo-file-upload-errors,
   .is-failed .repo-file-upload-errors, .is-hidden-file .repo-file-upload-errors,
   .is-too-big .repo-file-upload-errors, .is-too-many .repo-file-upload-errors,
-  dl.new-email-form, .listgroup-item + .listgroup-item, html[prefix] .Box-footer,
-  html[prefix] .footer, body.status hr,
+  dl.new-email-form, .listgroup-item + .listgroup-item, .Box-footer,
+  html[prefix] .Box-footer, html[prefix] .footer, body.status hr,
   body.zh_logged_in .zh-estimate-create-item,
   body.zh_logged_in .zh-issuecard-meta {
     border-top-color: #343434;
   }
   /* auto-generated rule for "border-top: 1px solid #e5e5e5 !important" */
-  html[prefix] .border-top, html[prefix] .border-y {
+  .border-top, .border-y, html[prefix] .border-top, html[prefix] .border-y {
     border-top-color: #343434 !important;
   }
   /* auto-generated rule for "border-bottom: 1px solid #e5e5e5" */
   .marketing-section, .blob-interaction-bar, .oauth-border, .filter-bar,
-  .access-token, .listgroup-header, html[prefix] .Box-body,
-  html[prefix] .data-table tbody tr:last-child td,
+  .access-token, .listgroup-header, .Box-body, .data-table td, .data-table th,
+  .data-table tbody tr:last-child th, .data-table tbody tr:last-child td,
+  html[prefix] .Box-body, html[prefix] .data-table tbody tr:last-child td,
   html[prefix] .data-table tbody tr:last-child th, html[prefix] hr,
   html[prefix] .menu-item, html[prefix] .site-header,
   html[prefix] .data-table td, html[prefix] .data-table th,
@@ -1864,7 +1927,7 @@
     border-bottom-color: #343434;
   }
   /* auto-generated rule for "border-bottom: 1px solid #e5e5e5 !important" */
-  html[prefix] .border-bottom, html[prefix] .border-y {
+  .border-bottom, .border-y, html[prefix] .border-bottom, html[prefix] .border-y {
     border-bottom-color: #343434 !important;
   }
   /* auto-generated rule for "border-left: 1px solid #e5e5e5" */
@@ -1872,26 +1935,27 @@
     border-left-color: #343434;
   }
   /* auto-generated rule for "border-left: 1px solid #e5e5e5 !important" */
-  html[prefix] .border-left {
+  .border-left, html[prefix] .border-left {
     border-left-color: #343434 !important;
   }
   /* auto-generated rule for "border-right: 1px solid #e5e5e5" */
-  html[prefix] .data-table td, html[prefix] .data-table th,
+  .data-table td, .data-table th, html[prefix] .data-table td,
+  html[prefix] .data-table th,
   body.zh_logged_in .zh-pipeline-collapsed .zh-pipeline-heading-container,
   body.zh_logged_in .zh-burndown-chart-container,
   body.zh_logged_in .zh-reports .stats-item {
     border-right-color: #343434;
   }
   /* auto-generated rule for "border-right: 1px solid #e5e5e5 !important" */
-  html[prefix] .border-right {
+  .border-right, html[prefix] .border-right {
     border-right-color: #343434 !important;
   }
   /* auto-generated rule for "border-bottom: 2px dashed #e5e5e5" */
-  html[prefix] .DashedConnection::before {
+  .DashedConnection::before, html[prefix] .DashedConnection::before {
     border-bottom-color: #343434;
   }
   /* auto-generated rule for "border-left: 3px solid #e5e5e5" */
-  html[prefix] .pullquote {
+  .pullquote, html[prefix] .pullquote {
     border-left-color: #343434;
   }
   /* auto-generated rule for "border-left: 4px solid #e5e5e5" */
@@ -2313,9 +2377,46 @@
   .file-diff-split .empty-cell {
     border-right-color: #343434;
   }
+  /* auto-generated rule for "border: 1px solid #e0e0e0" */
+  .plan-choice, body.status .well, body.status .cpt-tabs:not(.unstyled).mobile,
+  body.status .cpt-pill-group button.pill.active {
+    border-color: #343434;
+  }
+  /* auto-generated rule for "border: 1px dashed #e0e0e0 !important" */
+  body.status .cpt-table .content .table-row.blank-state {
+    border-color: #343434 !important;
+  }
+  /* auto-generated rule for "border-color: #e0e0e0" */
+  body.status .tooltip-base, body.status .layout-content.status-internal {
+    border-color: #343434;
+  }
+  /* auto-generated rule for "border-top: 1px solid #e0e0e0" */
+  .billing-line-item, .setup-info-module .setup-info-note,
+  .graphiql-container .variable-editor-title, .graphiql-container .footer,
+  .graphiql-ide, body.status .form-bordered .control-group.first-border {
+    border-top-color: #343434;
+  }
+  /* auto-generated rule for "border-bottom: 1px solid #e0e0e0" */
+  .graphiql-container .doc-category-title,
+  .graphiql-container .history-contents p,
+  body.status .form-bordered .control-group, body.status .modal .modal-header,
+  body.status .cpt-tabs:not(.unstyled).mobile.open li:last-of-type,
+  body.status .updates-dropdown-container .updates-dropdown .updates-dropdown-nav a {
+    border-bottom-color: #343434;
+  }
+  /* auto-generated rule for "border-left: 1px solid #e0e0e0" */
+  .graphiql-container .resultWrap, .graphiql-container .footer,
+  body.status .cpt-tabs:not(.unstyled).mobile.open li a {
+    border-left-color: #343434;
+  }
+  /* auto-generated rule for "border-right: 1px solid #e0e0e0" */
+  body.status .cpt-tabs:not(.unstyled).mobile.open li a,
+  body.status .updates-dropdown-container .updates-dropdown .updates-dropdown-nav a {
+    border-right-color: #343434;
+  }
   /* auto-generated rule for "border: 1px solid #eee" */
   .newsletter-frequency-choice, .thread-subscription-status, .two-factor-steps,
-  .qr-code-table, html[prefix] .blankslate code,
+  .qr-code-table, .blankslate code, html[prefix] .blankslate code,
   body[data-render-url] .render-info .message {
     border-color: #343434;
   }
@@ -2324,7 +2425,7 @@
     border-color: #343434;
   }
   /* auto-generated rule for "border-color: #eee !important" */
-  html[prefix] .border-gray-light {
+  .border-gray-light, html[prefix] .border-gray-light {
     border-color: #343434 !important;
   }
   /* auto-generated rule for "border-top: 1px solid #eee" */
@@ -2332,7 +2433,7 @@
   .manage-repo-access-team-item, .diffbar .table-of-contents li,
   .email-preference-exceptions .exception, .features-list .list-divider,
   .setup-form .setup-organization-next, .setup-form .tos-info,
-  .showcase-page-repo-list, html[prefix] .Box-row,
+  .showcase-page-repo-list, .Box-row, html[prefix] .Box-row,
   html[prefix] .sidebar-module ul li:last-child ul li:first-child,
   body.zh_logged_in #new_issue .discussion-sidebar h3 {
     border-top-color: #343434;
@@ -2343,7 +2444,8 @@
   .invited .team-member-list .list-item, .theme-picker-thumbs, .repo-list-item,
   .saved-reply-form .comment-body,
   .email-preference-exceptions .exception:last-child,
-  .setup-form .setup-organization-next, .setup-form .tos-info,
+  .setup-form .setup-organization-next, .setup-form .tos-info, .menu-item,
+  .menu-heading, .subnav-bordered, .markdown-body h1, .markdown-body h2,
   html[prefix] .menu-heading, html[prefix] .subnav-bordered,
   html[prefix] .markdown-body h1, html[prefix] .markdown-body h2,
   html[prefix] .headlines > li, html[prefix] .sidebar-module ul h3,
@@ -2452,7 +2554,8 @@
     border-left-color: #181818;
   }
   /* auto-generated rule for "border-right: 1px solid #fff" */
-  .AvatarStack-body .avatar, .BarChart-bar, html[prefix] .avatar-stack .avatar {
+  .AvatarStack-body .avatar, .BarChart-bar, .avatar-stack .avatar,
+  html[prefix] .avatar-stack .avatar {
     border-right-color: #181818;
   }
   /* auto-generated rule for "border-top: 2px solid #fff" */
@@ -2633,7 +2736,10 @@
   .clone-url-button.selected > .clone-url-link,
   .clone-url-button.selected > .clone-url-link:hover,
   .oauth-app-info-container dl.keys dd, .protected-branch-pusher,
-  .typeahead-result, .hljs, .hljs-keyword, .hljs-selector-tag, .hljs-subst,
+  .typeahead-result, .hljs, .hljs-keyword, .hljs-selector-tag, .hljs-subst, body,
+  .text-emphasized, .Box-row-link, .btn, .social-count, .form-control,
+  .form-select, p.explain strong, .Counter--gray-light, .menu-item .octicon,
+  .tabnav-tab.selected, .markdown-body span.frame span span,
   html[prefix] .text-emphasized, html[prefix] .Box-row-link,
   html[prefix] .social-count, html[prefix] .form-control,
   html[prefix] .form-select, html[prefix] p.explain strong,
@@ -2646,8 +2752,7 @@
   html[prefix] .octokit-language span, html[prefix] .headlines > li > a,
   html[prefix] .js-current .standalone a,
   html[prefix] .sidebar-module .disable > a, html[prefix] .content .anchor,
-  html[prefix] #markdown-toc li a, body,
-  body.status .dropdown .dropdown-menu li a,
+  html[prefix] #markdown-toc li a, body.status .dropdown .dropdown-menu li a,
   body.status .grouped-items-selector.inline .grouped-item.active,
   body.status .panel.panel-default .panel-heading,
   body.status .cpt-tabs:not(.unstyled) li.active a,
@@ -2788,7 +2893,8 @@
     color: #bebebe;
   }
   /* auto-generated rule for "color: #333 !important" */
-  html[prefix] .link-gray-dark, body.zh_logged_in .zhu-color-text {
+  .link-gray-dark, html[prefix] .link-gray-dark,
+  body.zh_logged_in .zhu-color-text {
     color: #bebebe !important;
   }
   /* auto-generated rule for "color: #3c4146" */
@@ -3061,7 +3167,9 @@
   .repo-file-upload-file-wrap .remove-file:hover,
   .mini-repo-list-item .repo-icon, .edit-profile-avatar .drag-and-drop,
   .user-key-email-unverified, .email-preference-exceptions h5,
-  .collaborators .collab-info, html[prefix] .btn .counter,
+  .collaborators .collab-info, .btn .counter, .form-checkbox .note,
+  .hfields .form-group dt label, h2.account, p.explain, .counter, .tabnav-tab,
+  .tabnav-extra, .subnav-item, html[prefix] .btn .counter,
   html[prefix] .form-checkbox .note, html[prefix] .hfields .form-group dt label,
   html[prefix] h2.account, html[prefix] p.explain, html[prefix] .counter,
   html[prefix] .tabnav-tab, html[prefix] .tabnav-extra,
@@ -3338,11 +3446,14 @@
   /* auto-generated rule for "color: #767676" */
   .link-small, .credit-card.normal .signature,
   .org-creation-questions .question-title i,
-  .user-identification-questions .question-title i,
-  html[prefix] .btn-outline.disabled, html[prefix] .btn-outline.disabled:hover,
-  html[prefix] .btn-outline:disabled, html[prefix] .btn-outline:disabled:hover,
-  html[prefix] .note, html[prefix] .drag-and-drop,
-  html[prefix] .drag-and-drop-error-info,
+  .user-identification-questions .question-title i, .btn-outline:disabled,
+  .btn-outline:disabled:hover, .btn-outline.disabled,
+  .btn-outline.disabled:hover, .note, .drag-and-drop, .drag-and-drop-error-info,
+  .filter-list.pjax-active .filter-item, .filter-item, .subnav-search-input,
+  .pullquote, html[prefix] .btn-outline.disabled,
+  html[prefix] .btn-outline.disabled:hover, html[prefix] .btn-outline:disabled,
+  html[prefix] .btn-outline:disabled:hover, html[prefix] .note,
+  html[prefix] .drag-and-drop, html[prefix] .drag-and-drop-error-info,
   html[prefix] .filter-list.pjax-active .filter-item, html[prefix] .filter-item,
   html[prefix] .subnav-search-input, html[prefix] .pullquote, html[prefix] body,
   html[prefix] .lead, html[prefix] .link-muted, html[prefix] .btn,
@@ -3376,9 +3487,9 @@
     color: #767676;
   }
   /* auto-generated rule for "color: #767676 !important" */
-  html[prefix] .text-gray, html[prefix] .link-gray, html[prefix] .muted-link,
-  html[prefix] .text-default, body.zh_logged_in .zh-muted-link,
-  body.zh_logged_in .zh-text-muted {
+  .text-gray, .link-gray, .muted-link, html[prefix] .text-gray,
+  html[prefix] .link-gray, html[prefix] .muted-link, html[prefix] .text-default,
+  body.zh_logged_in .zh-muted-link, body.zh_logged_in .zh-text-muted {
     color: #767676 !important;
   }
   /* auto-generated rule for "color: #a3aab1" */
@@ -3636,6 +3747,10 @@
   /* auto-generated rule for "color: #1074e7 !important" */
   .text-blue-mktg {
     color: /*[[base-color]]*/ #4f8cc9 !important;
+  }
+  /* auto-generated rule for "color: #1F61A0" */
+  .graphiql-container .field-name {
+    color: /*[[base-color]]*/ #4f8cc9;
   }
   /* auto-generated rule for "color: rgba(88,96,105,.5)" */
   .btn-link:disabled, .btn-link:disabled:hover {
@@ -4205,6 +4320,10 @@
   .ghh-theme-github .ghh-pull-meta .text-diff-deleted {
     color: #f44 !important;
   }
+  /* auto-generated rule for "color: #B11A04" */
+  .graphiql-container .keyword {
+    color: #f44;
+  }
   /* auto-generated rule for "color: #86181d" */
   .form-group.errored .error, .menu-item .menu-warning, .flash-error,
   .comment-form-error, .invalid-topic .delete-topic-button,
@@ -4546,6 +4665,10 @@
   body[class="page-responsive"] .color-yellow-7 {
     color: #cb4 !important;
   }
+  /* auto-generated rule for "color: #CA9800" */
+  .graphiql-container .type-name {
+    color: #cb4;
+  }
   /* auto-generated rule for "color: #b08800" */
   .deployment-status-label.is-in_progress, .deployment-status-label.is-pending,
   .deployment-status-label.is-queued,
@@ -4756,6 +4879,10 @@
   body[class="page-responsive"] .bg-yellow-2 {
     background-color: #651 !important;
   }
+  /* auto-generated rule for "color: #8B2BB9" */
+  .graphiql-container .arg-name {
+    color: #8368aa;
+  }
   /* auto-generated rule for "color: #6f42c1" */
   .illflow-purple .illflow-item .illflow-item-heading, .merged.octicon,
   .issue-list .title .merged.octicon, .type-icon-state-merged,
@@ -4884,7 +5011,7 @@
     text-shadow: none;
   }
   /* auto-generated rule for "background: rgba(0,0,0,.8)" */
-  .svg-tip, html[prefix] .tooltipped::after,
+  .svg-tip, .tooltipped::after, html[prefix] .tooltipped::after,
   body[data-render-url] .render-info .message,
   html.ghh-theme-classic .tooltipster-box {
     background: #242424;
@@ -4895,24 +5022,26 @@
     background-color: #242424;
   }
   /* auto-generated rule for "border-top-color: rgba(0,0,0,.8)" */
-  .svg-tip:after, html[prefix] .tooltipped-n::before,
+  .svg-tip:after, .tooltipped-n::before, .tooltipped-ne::before,
+  .tooltipped-nw::before, html[prefix] .tooltipped-n::before,
   html[prefix] .tooltipped-ne::before, html[prefix] .tooltipped-nw::before,
   html.ghh-theme-classic .tooltipster-top .tooltipster-arrow-border {
     border-top-color: #242424;
   }
   /* auto-generated rule for "border-bottom-color: rgba(0,0,0,.8)" */
+  .tooltipped-s::before, .tooltipped-se::before, .tooltipped-sw::before,
   html[prefix] .tooltipped-s::before, html[prefix] .tooltipped-se::before,
   html[prefix] .tooltipped-sw::before,
   html.ghh-theme-classic .tooltipster-bottom .tooltipster-arrow-border {
     border-bottom-color: #242424;
   }
   /* auto-generated rule for "border-left-color: rgba(0,0,0,.8)" */
-  html[prefix] .tooltipped-w::before,
+  .tooltipped-w::before, html[prefix] .tooltipped-w::before,
   html.ghh-theme-classic .tooltipster-left .tooltipster-arrow-border {
     border-left-color: #242424;
   }
   /* auto-generated rule for "border-right-color: rgba(0,0,0,.8)" */
-  html[prefix] .tooltipped-e::before,
+  .tooltipped-e::before, html[prefix] .tooltipped-e::before,
   html.ghh-theme-classic .tooltipster-right .tooltipster-arrow-border {
     border-right-color: #242424;
   }
@@ -5052,6 +5181,8 @@
   .team-label-ldap, .tree-finder-input, .tree-finder-input:focus,
   .hx_badge-search-container .hx_badge-input, .btn-purple:disabled,
   .btn-purple.disabled, .upload-enabled.focused .ais-SearchBox-input,
+  .btn:disabled:hover, .btn.disabled:hover, .btn-primary:disabled:hover,
+  .btn-primary.disabled:hover, .blankslate-clean-background,
   html[prefix] .btn-primary.disabled, html[prefix] .btn-primary.disabled:hover,
   html[prefix] .btn-primary:disabled, html[prefix] .btn-primary:disabled:hover,
   html[prefix] .blankslate-clean-background, html[prefix] .btn.disabled,
@@ -5160,9 +5291,9 @@
   a, .btn-link, .inline-form .btn-plain, .tabnav-tab,
   .filter-list.pjax-active .filter-item, .markdown-body table img,
   .markdown-body .emoji, .markdown-body pre code, .markdown-body pre tt,
-  .btn-transparent, html[prefix] a, html[prefix] .btn-link,
-  html[prefix] .inline-form .btn-plain, html[prefix] .tabnav-tab,
-  html[prefix] .filter-list.pjax-active .filter-item,
+  .btn-transparent, .avatar-stack .avatar:only-child, .jumbotron-shadow::after,
+  html[prefix] a, html[prefix] .btn-link, html[prefix] .inline-form .btn-plain,
+  html[prefix] .tabnav-tab, html[prefix] .filter-list.pjax-active .filter-item,
   html[prefix] .avatar-stack .avatar:only-child,
   html[prefix] .markdown-body .emoji, html[prefix] .markdown-body pre code,
   html[prefix] .markdown-body pre tt, html[prefix] .jumbotron-shadow::after,
@@ -5320,8 +5451,8 @@
   .theme-toggle, .tag-input input, .tree-browser-result mark,
   .toolbar-commenting .dropdown-item, .toolbar-item, .toolbar-item .menu-target,
   .wiki-footer .markdown-body img, .user-list li em, .ais-SearchBox-reset, mark,
-  .ais-Highlight-highlighted, body.status .cpt-toggle,
-  body[class="page-responsive"] .dropdown-signout,
+  .ais-Highlight-highlighted, .blankslate-clean-background,
+  body.status .cpt-toggle, body[class="page-responsive"] .dropdown-signout,
   body[class="page-responsive"] .content-attachment-details[open] .max--md .content-attachment-content--gradient,
   body[class="page-responsive"] .header-search-input,
   body[class="page-responsive"] button,
@@ -5376,7 +5507,11 @@
   .clone-url-button > .clone-url-link:active, .btn-secret.selected,
   .btn-secret:active, .btn-purple:active, .btn-purple.selected,
   [open] > .btn-purple, .btn-purple:disabled, .btn-purple.disabled,
-  html[prefix] .btn-primary.selected,
+  .btn.zeroclipboard-is-active, .btn:disabled:hover, .btn.disabled:hover,
+  .btn-primary.zeroclipboard-is-active, .btn-outline.zeroclipboard-is-hover,
+  .btn-outline.zeroclipboard-is-active, .btn-outline:disabled,
+  .btn-outline:disabled:hover, .btn-outline.disabled,
+  .btn-outline.disabled:hover, html[prefix] .btn-primary.selected,
   html[prefix] .btn-primary.zeroclipboard-is-active,
   html[prefix] .btn-primary:active, html[prefix] .btn-danger.selected,
   html[prefix] .btn-danger:active, html[prefix] .btn-outline,

--- a/tools/generate.js
+++ b/tools/generate.js
@@ -293,7 +293,11 @@ const sources = [
   {url: "https://github.com"},
   {url: "https://gist.github.com"},
   {url: "https://help.github.com"},
-  {url: "https://graphql-explorer.githubapp.com/"},
+  {
+    url: "https://graphql-explorer.githubapp.com/", 
+    prefix: ".graphql-container",
+    match: [".graphql-container"],
+  },
   {url: "https://developer.github.com", prefix: "html[prefix]"},
   {
     url: "https://www.githubstatus.com/",

--- a/tools/generate.js
+++ b/tools/generate.js
@@ -17,7 +17,9 @@ let mappings = {
   // ==========================================================================
   // Background
   // ==========================================================================
+  "$background: white": "#181818", // graphql explorer
   "$background: #fff": "#181818",
+  "$background: #ffffff": "#181818", // graphql explorer
   "$background: #ffe": "#242424",
   "$background: #fdfdfd": "#1c1c1c",
   "$background: #fafbfc": "#181818",
@@ -57,6 +59,8 @@ let mappings = {
   "$border: #959da5": "#484848",
   "$border: #c3c8cf": "#484848",
   "$border: #dfe2e5": "#343434",
+  "$border: #d6d6d6": "#343434", // graphql explorer
+  "$border: #d3d6db": "#343434", // graphql explorer
   "$border: #d1d5da": "#404040",
   "$border: #ddd": "#343434",
   "$border: #e1e4e8": "#343434",
@@ -64,6 +68,7 @@ let mappings = {
   "$border: #e6ebf1": "#343434",
   "$border: #e9e9e9": "#343434", // zenhub
   "$border: #eaecef": "#343434",
+  "$border: #e0e0e0": "#343434", // graphql explorer
   "$border: #eee": "#343434",
   "$border: #f6f8fa": "#202020",
   "$border: #f8f8f8": "#343434",
@@ -129,6 +134,7 @@ let mappings = {
   "color: #3c4146": "color: #bebebe",
   "color: #444d56": "color: #afafaf",
   "color: #1b1f23": "color: #afafaf",
+  "color: #555": "color: #bebebe", // graphql explorer
   "color: #586069": "color: #afafaf",
   "color: #666": "color: #949494",
   "color: #6a737d": "color: #949494",
@@ -158,6 +164,7 @@ let mappings = {
 
   "color: #0366d6": "color: /*[[base-color]]*/ #4f8cc9", // needs to be after #333
   "color: #1074e7": "color: /*[[base-color]]*/ #4f8cc9",
+  "color: #1F61A0": "color: /*[[base-color]]*/ #4f8cc9", //  graphql explorer
   "color: rgba(88,96,105,.5)": "color: rgba(148,148,148,.5)",
   "color: #24292e": "color: #d2d2d2",
   "color: #2f363d": "color: #bebebe",
@@ -203,6 +210,7 @@ let mappings = {
 
   // red
   "color: #cb2431": "color: #f44",
+  "color: #B11A04": "color: #f44", // graphql explorer
   "color: #86181d": "color: #f44",
   "$background: #d73a49": "#f44",
   "$background: #cb2431": "#911",
@@ -231,6 +239,7 @@ let mappings = {
   "color: rgba(47,38,6,.5)": "color: #cb4",
   "color: rgba(115,92,15,.5)": "color: rgba(204,187,68,.5)",
   "color: #dbab09": "color: #cb4",
+  "color: #CA9800": "color: #cb4", // graphql explorer
   "color: #b08800": "color: #cb4",
   "color: #735c0f": "color: #bba257",
   "color: #613A00": "color: #bba257",
@@ -251,6 +260,7 @@ let mappings = {
   "$background: #fff5b1": "#651",
 
   // purple
+  "color: #8B2BB9": "color: #8368aa", // graphql explorer
   "color: #6f42c1": "color: #8368aa",
   "$background: #6f42c1": "#8368aa",
   "$background: #f8f4ff": "#213",
@@ -283,6 +293,7 @@ const sources = [
   {url: "https://github.com"},
   {url: "https://gist.github.com"},
   {url: "https://help.github.com"},
+  {url: "https://graphql-explorer.githubapp.com/"},
   {url: "https://developer.github.com", prefix: "html[prefix]"},
   {
     url: "https://www.githubstatus.com/",

--- a/tools/generate.js
+++ b/tools/generate.js
@@ -294,7 +294,7 @@ const sources = [
   {url: "https://gist.github.com"},
   {url: "https://help.github.com"},
   {
-    url: "https://graphql-explorer.githubapp.com/", 
+    url: "https://graphql-explorer.githubapp.com/",
     prefix: ".graphql-container",
     match: [".graphql-container"],
   },


### PR DESCRIPTION
I was playing around with this page earlier and found a number of unstyled parts due to a style sheet that wasn't being included in the generator.

I added the url in and started adding some of the missing colors but wanted to PR the changes to see if this was adding too many new selectors/rules in vs. manually styling it. There's some manual styles that can be removed but I didn't get to those yet.

This is still a work in progress but I haven't seen any issues elsewhere on the site from it.