### PR TITLE
Add support for font-feature-settings on the code font

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -5758,6 +5758,7 @@
   pre, code, tt, kbd:not(.badmono), samp, .blob-code, .file-data pre, .line-data,
   #gist-form .file .input textarea, .blob-code-inner {
     font-family: "/*[[font-choice]]*/", Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
+    font-feature-settings: /*[[font-features]]*/ !important;
     font-size: /*[[font-size-choice]]*/ !important;
   }
   /* Base link colors */

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -194,6 +194,7 @@
   } EOT;
 }
 @advanced text font-choice "Code Font" "Menlo"
+@advanced text font-features "Code Font Features" normal
 @advanced text font-size-choice "Code Font Size" "default (eg 10px)"
 @advanced dropdown code-wrap "Code Wrap" {
   nowrap "No Wrap" <<<EOT
@@ -5973,6 +5974,7 @@
   pre, code, tt, kbd:not(.badmono), samp, .blob-code, .file-data pre, .line-data,
   #gist-form .file .input textarea, .blob-code-inner {
     font-family: "/*[[font-choice]]*/", Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
+    font-feature-settings: /*[[font-features]]*/ !important;
     font-size: /*[[font-size-choice]]*/ !important;
   }
   /* Base link colors */

--- a/tools/usercss-template.css
+++ b/tools/usercss-template.css
@@ -49,6 +49,7 @@
   {{tab-sizes}}
 }
 @advanced text font-choice "Code Font" "{{font}}"
+@advanced text font-features "Code Font Features" normal
 @advanced text font-size-choice "Code Font Size" "{{fontSize}}"
 @advanced dropdown code-wrap "Code Wrap" {
   nowrap "No Wrap" <<<EOT


### PR DESCRIPTION
Fonts like [Fira Code](https://github.com/tonsky/FiraCode#stylistic-sets) and [Inter](https://rsms.me/inter/#features) (the font used by GitHub on their marketing pages) support feature settings. I use Fira Code in my editors and more recently started using on GitHub for consistency. The missing part was being able to turn some of these features on like I can in VSCode. I've been running this change for some time now in its own style with no issues, but I wanted to PR it in case there was something I was missing when adding a new setting to the theme.

The default value is set to `normal` which is the browser default, but if you change it to something like `'ss02', 'ss03', 'ss04'` when using Fira Code you'll notice a difference in how `<=`, `&`, and `$` are displayed.

More info on the setting:

- https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings
- https://css-tricks.com/almanac/properties/f/font-feature-settings/
