### PR TITLE
fix toolbar shadow offset

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -9121,6 +9121,9 @@
   .toolbar-shadow[style*="top: 60px"] {
     margin-top: -60px !important;
   }
+  .toolbar-shadow[style*="top: 133px"] {
+    margin-top: -133px !important;
+  }
   .gh-header-shadow {
     border: none !important;
     box-shadow: 0 0 .75rem rgba(0, 0, 0, .7) !important;


### PR DESCRIPTION
In the PR diff view when using the new notifications beta, the toolbar shadow is offset by 133px. With this style it causes the shadow to overlay the diff view.
This fix is equivalent to the fix for issue #1056
fixes #1063 