### PR TITLE
Remove unneeded quotes from css values

### DIFF
--- a/tools/usercss-template.css
+++ b/tools/usercss-template.css
@@ -28,7 +28,7 @@
   none "None" <<<EOT
   none EOT;
 }
-@advanced text bg-custom "Custom Background" "{{image}}"
+@advanced text bg-custom "Custom Background" {{image}}
 @advanced dropdown bg-options "Background image type" {
   Tiled "Tiled" <<<EOT
   background-repeat: repeat !important;
@@ -48,9 +48,9 @@
 @advanced dropdown tab-size "Code Tab size" {
   {{tab-sizes}}
 }
-@advanced text font-choice "Code Font" "{{font}}"
+@advanced text font-choice "Code Font" {{font}}
 @advanced text font-features "Code Font Features" normal
-@advanced text font-size-choice "Code Font Size" "{{fontSize}}"
+@advanced text font-size-choice "Code Font Size" {{fontSize}}
 @advanced dropdown code-wrap "Code Wrap" {
   nowrap "No Wrap" <<<EOT
   EOT;


### PR DESCRIPTION
This is based on the conversation in https://github.com/StylishThemes/GitHub-Dark/pull/1049#discussion_r364920445. I'd like someone else to test this out before it gets merged. In Chrome I didn't see any issues with this change.