### PR TITLE
Fix code snippet background in security alerts

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -6925,7 +6925,7 @@
     background-image: none !important;
   }
   /* end remap-css rules */
-  body {
+  body, body.bg-gray {
     background-color: #202020 !important;
     background-image: var(--bg-img) !important;
     background-clip: border-box !important;
@@ -7914,7 +7914,6 @@
   a.card.bg-gray-light:hover, .add-member-team-list .team-row-header,
   .pagination .gap, .pagination .disabled, .pagination .gap:hover,
   .pagination .disabled:hover, .listgroup-header, .merge-status-item,
-  .bg-gray:not(body):not(.team-discussions-container):not(.highlight),
   .Header .header-search-wrapper, .Header .header-search-wrapper input,
   .user-key-email-unverified, .action-card-header::before,
   .commits-listing .octicon-git-commit,

--- a/github-dark.css
+++ b/github-dark.css
@@ -7914,7 +7914,7 @@
   a.card.bg-gray-light:hover, .add-member-team-list .team-row-header,
   .pagination .gap, .pagination .disabled, .pagination .gap:hover,
   .pagination .disabled:hover, .listgroup-header, .merge-status-item,
-  .bg-gray:not(body):not(.team-discussions-container),
+  .bg-gray:not(body):not(.team-discussions-container):not(.highlight),
   .Header .header-search-wrapper, .Header .header-search-wrapper input,
   .user-key-email-unverified, .action-card-header::before,
   .commits-listing .octicon-git-commit,
@@ -10987,7 +10987,7 @@
   #facebox pre, .blob-expanded, .terminal, .copyable-terminal,
   #notebook .input_area, .blob-code-context, .markdown-format code, .api pre,
   .api li:not(a) code, .hook-delivery-details pre, .hook-delivery-container pre,
-  .code-list .file-box, .CodeMirror {
+  .code-list .file-box, .CodeMirror, .highlight.bg-gray {
     background-color: var(--ghd-code-background, #141414) !important;
     color: var(--ghd-code-color, #ccc) !important;
   }


### PR DESCRIPTION
Since this uses `:not()` I wanted to PR it so @silverwind can approve the use of it or tell me how horrible this is 😃

This can be seen under the [Security > Alerts](https://github.com/StylishThemes/GitHub-Dark/network/alerts) section of a repo with an open alert. I'm not sure if it's an issue for all syntax themes, I'm using Monokai here.

Before | After
-- | --
![github com_xt0rted_dotnet-format_network_alert_package-lock json_minimist_open (1)](https://user-images.githubusercontent.com/831974/79049260-890e3a80-7bf0-11ea-94cd-bd256dab08b5.png) | ![github com_xt0rted_dotnet-format_network_alert_package-lock json_minimist_open](https://user-images.githubusercontent.com/831974/79049259-86abe080-7bf0-11ea-8f19-e2404549d013.png)
