### PR TITLE
Add rgb color to menu-item.

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1591,9 +1591,10 @@
   html[prefix] .highlight pre code {
     background-color: transparent;
   }
-  /* developer.github.com: "border-bottom: 1px solid #e5e5e5" */
+  /* developer.github.com: "border-bottom: 1px solid #e5e5e5", "color: rgb(79, 140, 201)" */
   html[prefix] .menu-item, html[prefix] .site-header {
     border-bottom-color: #343434;
+    color: rgb(79, 140, 201);
   }
   /* developer.github.com: "border: 1px solid #e5e5e5" */
   html[prefix] .example {
@@ -2628,9 +2629,10 @@
     background-image: none;
     border-color: #404040;
   }
-  /* graphql.github.com: "border-bottom: 1px solid #e1e4e8" */
+  /* graphql.github.com: "border-bottom: 1px solid #e1e4e8", "color: rgb(79, 140, 201)" */
   #graphiql .menu-item {
     border-bottom-color: #343434;
+    color: rgb(79, 140, 201);
   }
   /* graphql.github.com: "background-color: #f6f8fa" */
   #graphiql .menu-item:hover {
@@ -7734,9 +7736,10 @@
     background-image: none;
     border-color: #404040;
   }
-  /* github.com: "border-bottom: 1px solid #e1e4e8" */
+  /* github.com: "border-bottom: 1px solid #e1e4e8", "color: rgb(79, 140, 201)" */
   .menu-item {
     border-bottom-color: #343434;
+    color: rgb(79, 140, 201);
   }
   /* github.com: "background-color: #f6f8fa" */
   .menu-item:hover {

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -1806,9 +1806,10 @@
   html[prefix] .highlight pre code {
     background-color: transparent;
   }
-  /* developer.github.com: "border-bottom: 1px solid #e5e5e5" */
+  /* developer.github.com: "border-bottom: 1px solid #e5e5e5", "color: rgb(79, 140, 201)" */
   html[prefix] .menu-item, html[prefix] .site-header {
     border-bottom-color: #343434;
+    color: rgb(79, 140, 201);
   }
   /* developer.github.com: "border: 1px solid #e5e5e5" */
   html[prefix] .example {
@@ -2843,9 +2844,10 @@
     background-image: none;
     border-color: #404040;
   }
-  /* graphql.github.com: "border-bottom: 1px solid #e1e4e8" */
+  /* graphql.github.com: "border-bottom: 1px solid #e1e4e8", "color: rgb(79, 140, 201)" */
   #graphiql .menu-item {
     border-bottom-color: #343434;
+    color: rgb(79, 140, 201);
   }
   /* graphql.github.com: "background-color: #f6f8fa" */
   #graphiql .menu-item:hover {
@@ -7949,9 +7951,10 @@
     background-image: none;
     border-color: #404040;
   }
-  /* github.com: "border-bottom: 1px solid #e1e4e8" */
+  /* github.com: "border-bottom: 1px solid #e1e4e8", "color: rgb(79, 140, 201)" */
   .menu-item {
     border-bottom-color: #343434;
+    color: rgb(79, 140, 201);
   }
   /* github.com: "background-color: #f6f8fa" */
   .menu-item:hover {


### PR DESCRIPTION
Adds rgb color style to `.menu-item` on the profile settings page in GitHub's new UI.

Before:
![image](https://user-images.githubusercontent.com/25370364/84957551-54889480-b0f3-11ea-959e-54acd7bd798a.png)
After:
![image](https://user-images.githubusercontent.com/25370364/84957592-72ee9000-b0f3-11ea-9733-9808847f5b70.png)
