### PR TITLE
fix disabled button color

### DIFF
--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -415,17 +415,17 @@
   .btn-primary.selected, .btn-primary:active, .btn-primary[aria-selected=true] {
     background-color: #595;
   }
-  /* gist.github.com: "hsla(0,0%,100%,.8)", "#94d3a2", "rgba(27,31,35,.1)", "rgba(27,31,35,.1)" */
+  /* gist.github.com: "color: hsla(0,0%,100%,.8)", "#94d3a2", "rgba(27,31,35,.1)", "rgba(27,31,35,.1)" */
   .btn-primary.disabled, .btn-primary:disabled,
   .btn-primary[aria-disabled=true] {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
     background-color: #040;
     border-color: rgba(220, 220, 220, .1);
     box-shadow: 0 1px 0 #000, inset 0 1px 0 hsla(0, 0%, 100%, .03);
   }
-  /* gist.github.com: "hsla(0,0%,100%,.8)" */
+  /* gist.github.com: "color: hsla(0,0%,100%,.8)" */
   .btn-primary .octicon {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
   }
   /* gist.github.com: "#cb2431" */
   .btn-danger {
@@ -2458,9 +2458,9 @@
   .section-codespaces-develop-night .codespaces-develop-header {
     color: #fff;
   }
-  /* gist.github.com: "hsla(0,0%,100%,.8)" */
+  /* gist.github.com: "color: hsla(0,0%,100%,.8) !important" */
   .section-codespaces-develop-night .codespaces-develop-text {
-    color: hsla(0, 0%, 100%, .8) !important;
+    color: hsla(0, 0%, 100%, .3) !important;
   }
   /* gist.github.com: "box-shadow: none" */
   .section-codespaces-develop-night .codespaces-sun {
@@ -10281,18 +10281,18 @@
   body[class="page-responsive"] .btn-primary[aria-selected=true] {
     background-color: #595;
   }
-  /* github-mobile: "hsla(0,0%,100%,.8)", "#94d3a2", "rgba(27,31,35,.1)", "rgba(27,31,35,.1)" */
+  /* github-mobile: "color: hsla(0,0%,100%,.8)", "#94d3a2", "rgba(27,31,35,.1)", "rgba(27,31,35,.1)" */
   body[class="page-responsive"] .btn-primary.disabled,
   body[class="page-responsive"] .btn-primary:disabled,
   body[class="page-responsive"] .btn-primary[aria-disabled=true] {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
     background-color: #040;
     border-color: rgba(220, 220, 220, .1);
     box-shadow: 0 1px 0 #000, inset 0 1px 0 hsla(0, 0%, 100%, .03);
   }
-  /* github-mobile: "hsla(0,0%,100%,.8)" */
+  /* github-mobile: "color: hsla(0,0%,100%,.8)" */
   body[class="page-responsive"] .btn-primary .octicon {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
   }
   /* github-mobile: "#cb2431" */
   body[class="page-responsive"] .btn-danger {
@@ -11828,17 +11828,17 @@
   .btn-primary.selected, .btn-primary:active, .btn-primary[aria-selected=true] {
     background-color: #595;
   }
-  /* github.com: "hsla(0,0%,100%,.8)", "#94d3a2", "rgba(27,31,35,.1)", "rgba(27,31,35,.1)" */
+  /* github.com: "color: hsla(0,0%,100%,.8)", "#94d3a2", "rgba(27,31,35,.1)", "rgba(27,31,35,.1)" */
   .btn-primary.disabled, .btn-primary:disabled,
   .btn-primary[aria-disabled=true] {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
     background-color: #040;
     border-color: rgba(220, 220, 220, .1);
     box-shadow: 0 1px 0 #000, inset 0 1px 0 hsla(0, 0%, 100%, .03);
   }
-  /* github.com: "hsla(0,0%,100%,.8)" */
+  /* github.com: "color: hsla(0,0%,100%,.8)" */
   .btn-primary .octicon {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
   }
   /* github.com: "#cb2431" */
   .btn-danger {
@@ -19817,9 +19817,9 @@
   .section-codespaces-develop-night .codespaces-develop-header {
     color: #fff;
   }
-  /* github.com: "hsla(0,0%,100%,.8)" */
+  /* github.com: "color: hsla(0,0%,100%,.8) !important" */
   .section-codespaces-develop-night .codespaces-develop-text {
-    color: hsla(0, 0%, 100%, .8) !important;
+    color: hsla(0, 0%, 100%, .3) !important;
   }
   /* github.com: "box-shadow: none" */
   .section-codespaces-develop-night .codespaces-sun {
@@ -23736,9 +23736,9 @@
   .site-header-nav a {
     color: #fff;
   }
-  /* developer.github.com: "rgba(255,255,255,.8)" */
+  /* developer.github.com: "color: hsla(0,0%,100%,.8)" */
   .flash-header {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
   }
   /* developer.github.com: "color: #fff !important" */
   .flash-header a {
@@ -31413,9 +31413,9 @@
   html[class^="ghh"] .ghh button.ghh-primary:hover {
     background-color: /*[[base-color]]*/;
   }
-  /* github-hovercard: "rgba(255,255,255,0.8)" */
+  /* github-hovercard: "color: hsla(0,0%,100%,.8)" */
   html[class^="ghh"] .ghh button.ghh-aux {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
   }
   /* github-hovercard: "color: #fff" */
   html[class^="ghh"] .ghh .ghh-state,
@@ -31589,7 +31589,7 @@
     background-color: #181818;
   }
   /* gitako: "#e1e4e8" */
-  .gitako-ready .pagehead.repohead {
+  .gitako-ready main > *:first-child {
     box-shadow: inset 0 -1px 0 #343434;
   }
   /* gitako: "#d1d5da", "#fafbfc" */
@@ -34687,9 +34687,9 @@
   .cpt-notification {
     color: #fff;
   }
-  /* githubstatus.com: "rgba(255,255,255,0.8)" */
+  /* githubstatus.com: "color: hsla(0,0%,100%,.8)" */
   .cpt-notification .close {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
   }
   /* githubstatus.com: "color: #fff" */
   .cpt-notification .close:hover, .cpt-notification a:not(.close),
@@ -34965,9 +34965,9 @@
   .layout-content.status.status-index .unresolved-incidents .unresolved-incident .incident-title a:hover {
     color: #fff;
   }
-  /* githubstatus.com: "rgba(255,255,255,0.8)" */
+  /* githubstatus.com: "color: hsla(0,0%,100%,.8)" */
   .layout-content.status.status-index .page-status .last-updated-stamp {
-    color: hsla(0, 0%, 100%, .8);
+    color: hsla(0, 0%, 100%, .3);
   }
   /* githubstatus.com: "color: #fff" */
   .layout-content.status.status-full-history .show-filter.open {

--- a/src/gen/mappings.js
+++ b/src/gen/mappings.js
@@ -272,6 +272,7 @@ module.exports.mappings = {
   "color: rgba(27,31,35,.3)": "color: rgba(230,230,230,.3)",
   "color: rgba(36,41,46,.4)": "color: rgba(210,210,210,.4)",
   "color: rgb(36,41,46)": "color: rgb(210,210,210) !important", // notifications preview
+  "color: hsla(0,0%,100%,.8)": "color: hsla(0,0%,100%,.3)",
 
   "fill: #959da5": "fill: #757575",
 


### PR DESCRIPTION
This is how a disabled button looks,

![Capture](https://user-images.githubusercontent.com/31389848/87795929-00371880-c849-11ea-9fe0-b4455ac58dae.PNG)

Looks anything BUT.

re: #1154 **issue 2**

The reason why I PR this is for @silverwind to see how using `$color` for buttons is less than ideal idea because whats good in one value for some property in a rule elsewhere isnt necessarily good for another rule with a different property, in this case this PR is good for disabled button text color but not good for other rules.

Read the diff and see the wack-a-mole game

I cant commit this in good conscience and manual fixes at this level is not something I want to revisit.
