### PR TITLE
Use CSS block as value for font-size-choice

### DIFF
--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -176,13 +176,14 @@
 }
 @advanced text font-choice "Code Font" Menlo
 @advanced text font-features "Code Font Features" normal
-@advanced text font-size-choice "Code Font Size (e.g. 12px)" default
+@advanced text code-font-size "Code Font Size (e.g. 12px)" default
 ==/UserStyle== */
 @-moz-document regexp("^https?://((education|gist|graphql|guides|docs|raw|resources|status|developer|support|vscode-auth)\\.)?github\\.com/((?!generated_pages/preview).)*$"), domain("githubusercontent.com"), domain("www.githubstatus.com"), domain("stylishthemes.github.io") {
   :root {
     --ghd-bg-custom: /*[[bg-custom]]*/;
     --ghd-bg-img: /*[[bg-choice]]*/;
     --ghd-bg-color: /*[[bg-color]]*/;
+    --ghd-code-font-size: /*[[code-font-size]]*/;
     --ghd-code-background: #141414;
     --ghd-code-color: #ccc;
   }
@@ -20580,7 +20581,7 @@
   #gist-form .file .input textarea, .blob-code-inner {
     font-family: "/*[[font-choice]]*/", Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
     font-feature-settings: /*[[font-features]]*/ !important;
-    font-size: /*[[font-size-choice]]*/ !important;
+    font-size: var(--ghd-code-font-size) !important;
   }
   /* Base link colors */
   table.files .octicon-file-directory,

--- a/index.html
+++ b/index.html
@@ -1860,7 +1860,7 @@ module.exports = function(grunt) {
     pattern: '/*[[font-choice]]*/',
     replacement: config.font
   }, {
-    pattern: '/*[[font-size-choice]]*/',
+    pattern: '/*[[code-font-size]]*/',
     replacement: config.fontSize
   }, {
     pattern: '/*[[code-wrap]]*/',

--- a/src/main.css
+++ b/src/main.css
@@ -41,7 +41,7 @@
   #gist-form .file .input textarea, .blob-code-inner {
     font-family: "/*[[font-choice]]*/", Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
     font-feature-settings: /*[[font-features]]*/ !important;
-    font-size: /*[[font-size-choice]]*/ !important;
+    font-size: var(--ghd-code-font-size) !important;
   }
   /* Base link colors */
   table.files .octicon-file-directory,

--- a/src/template.css
+++ b/src/template.css
@@ -65,5 +65,5 @@
 }
 @advanced text font-choice "Code Font" Menlo
 @advanced text font-features "Code Font Features" normal
-@advanced text font-size-choice "Code Font Size (e.g. 12px)" default
+@advanced text code-font-size "Code Font Size (e.g. 12px)" default
 ==/UserStyle== */

--- a/src/vars.css
+++ b/src/vars.css
@@ -3,6 +3,7 @@
     --ghd-bg-custom: /*[[bg-custom]]*/;
     --ghd-bg-img: /*[[bg-choice]]*/;
     --ghd-bg-color: /*[[bg-color]]*/;
+    --ghd-code-font-size: /*[[code-font-size]]*/;
     --ghd-code-background: #141414;
     --ghd-code-color: #ccc;
   }


### PR DESCRIPTION
This lets us fall back to the original GitHub CSS if desired,
but also doesn't rely on generating invalid CSS.

In response to #1193 and #831 