### PR TITLE
fix: update prose-diff colors for added lines

### DIFF
--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -4498,6 +4498,10 @@
     background-color: /*[[base-color]]*/;
     border-color: /*[[base-color]]*/;
   }
+  /* gist.github.com: "#e6ffed" */
+  .blob-code-addition {
+    background-color: #002800;
+  }
   /* gist.github.com: "color: #24292e" */
   .blob-code-addition .x {
     color: #c6c6c6;
@@ -5107,10 +5111,15 @@
     color: #d82828;
     background-color: #300;
   }
-  /* gist.github.com: "#2cbe4e" */
+  /* gist.github.com: "#e6ffed", "#2cbe4e" */
   .prose-diff .changed .added, .prose-diff .changed ins,
   .prose-diff .changed ins code, .prose-diff .changed ins pre {
+    background-color: #002800;
     border-bottom-color: #373;
+  }
+  /* gist.github.com: "#e6ffed" */
+  .prose-diff > .markdown-body li ul.added {
+    background-color: #002800;
   }
   /* gist.github.com: "#cb2431", "#ffeef0" */
   .prose-diff > .markdown-body li ul.removed {
@@ -5131,6 +5140,10 @@
   .prose-diff > .markdown-body th.changed {
     background-color: #261d08;
     border-left-color: #404040;
+  }
+  /* gist.github.com: "#e6ffed" */
+  .prose-diff > .markdown-body li:not(.moved).added {
+    background-color: #002800;
   }
   /* gist.github.com: "#cb2431", "#ffeef0" */
   .prose-diff > .markdown-body li:not(.moved).removed {
@@ -11451,6 +11464,10 @@
     color: /*[[base-color]]*/;
     background-color: initial;
   }
+  /* github-mobile: "#e6ffed" */
+  body[class="page-responsive"] .diff-view + .js-comments-holder .blob-code-addition {
+    background-color: #002800;
+  }
   /* github-mobile: "#ffeef0" */
   body[class="page-responsive"] .diff-view + .js-comments-holder .blob-code-deletion,
   body[class="page-responsive"] .diff-view + .js-comments-holder .blob-num-deletion {
@@ -11508,6 +11525,10 @@
   /* github-mobile: "#f5f0ff" */
   body[class="page-responsive"] .diff-view .file .blob-num-hunk {
     background-color: #213;
+  }
+  /* github-mobile: "#e6ffed" */
+  body[class="page-responsive"] .diff-view .file .blob-code-addition {
+    background-color: #002800;
   }
   /* github-mobile: "#ffeef0" */
   body[class="page-responsive"] .diff-view .file .blob-code-deletion,
@@ -15505,6 +15526,10 @@
     background-color: /*[[base-color]]*/;
     border-color: /*[[base-color]]*/;
   }
+  /* github.com: "#e6ffed" */
+  .blob-code-addition {
+    background-color: #002800;
+  }
   /* github.com: "color: #24292e" */
   .blob-code-addition .x {
     color: #c6c6c6;
@@ -16114,10 +16139,15 @@
     color: #d82828;
     background-color: #300;
   }
-  /* github.com: "#2cbe4e" */
+  /* github.com: "#e6ffed", "#2cbe4e" */
   .prose-diff .changed .added, .prose-diff .changed ins,
   .prose-diff .changed ins code, .prose-diff .changed ins pre {
+    background-color: #002800;
     border-bottom-color: #373;
+  }
+  /* github.com: "#e6ffed" */
+  .prose-diff > .markdown-body li ul.added {
+    background-color: #002800;
   }
   /* github.com: "#cb2431", "#ffeef0" */
   .prose-diff > .markdown-body li ul.removed {
@@ -16138,6 +16168,10 @@
   .prose-diff > .markdown-body th.changed {
     background-color: #261d08;
     border-left-color: #404040;
+  }
+  /* github.com: "#e6ffed" */
+  .prose-diff > .markdown-body li:not(.moved).added {
+    background-color: #002800;
   }
   /* github.com: "#cb2431", "#ffeef0" */
   .prose-diff > .markdown-body li:not(.moved).removed {

--- a/src/gen/mappings.js
+++ b/src/gen/mappings.js
@@ -156,6 +156,7 @@ module.exports.mappings = {
   "$color: #94d3a2": "#040", // .btn-primary.disabled
   "$color: #a2cbac": "#040",
   "$color: #dcffe4": "#002800",
+  "$color: #e6ffed": "#002800",
   "$color: #f0fff4": "#002800",
 
   // purple


### PR DESCRIPTION
Hi, this patch will fix the following specificity issue:

|Before|After|
|-------|------|
|![image][1]|![image][2]|

Code in question: `.prose-diff > .markdown-body li ul.added`
Example page: [here][3] (Display the rich content)

I looked into the source code and it seems to me that using `!important` won't cause any conflicts. I also fixed `border-bottom` because some elements remove it entirely.


[1]: https://user-images.githubusercontent.com/18245694/91337952-73cb2e80-e7d4-11ea-8e8c-5bb624c0af43.png
[2]: https://user-images.githubusercontent.com/18245694/91338030-952c1a80-e7d4-11ea-948d-58b52c761b90.png
[3]: https://github.com/hlissner/doom-emacs/pull/3815/files#diff-875e1886e8077a8e8235882e7879d3e2