### PR TITLE
Add CSS vars for line numbers in diffs

### DIFF
--- a/src/vars.css
+++ b/src/vars.css
@@ -177,10 +177,14 @@
     --color-current-user-tip-border: #246;
     --color-diff-blob-addition-line-bg: #002800;
     --color-diff-blob-addition-num-bg: #0a320a;
+    --color-diff-blob-addition-num-hover-text: #e6e6e6;
+    --color-diff-blob-addition-num-text: #939393;
     --color-diff-blob-addition-word-bg: #252;
     --color-diff-blob-comment-button-icon: #fff;
     --color-diff-blob-deletion-line-bg: #380000;
     --color-diff-blob-deletion-num-bg: #420a0a;
+    --color-diff-blob-deletion-num-hover-text: #e6e6e6;
+    --color-diff-blob-deletion-num-text: #939393;
     --color-diff-blob-deletion-word-bg: #622;
     --color-diff-blob-empty-block-bg: #282828;
     --color-diff-blob-expander-hover-bg: /*[[base-color]]*/;


### PR DESCRIPTION
Previously, certain line numbers on diff views would be indiscernible from their backgrounds. For example…

Before:
![image](https://user-images.githubusercontent.com/27117322/133351205-0730b0b0-7f73-42ae-8bf5-ed11081ab776.png)

After:
![image](https://user-images.githubusercontent.com/27117322/133351291-fa690101-3ca3-4b3e-96e8-e59f93076724.png)