### PR TITLE
Add more `--color-attention` vars

### DIFF
--- a/src/vars.css
+++ b/src/vars.css
@@ -39,7 +39,10 @@
     --color-ansi-white: #e1e4e8;
     --color-ansi-yellow-bright: #fff5b1;
     --color-ansi-yellow: #ffea7f;
+    --color-attention-fg: #e4da9b;
     --color-attention-emphasis: #cb4;
+    --color-attention-muted: #7c7022;
+    --color-attention-subtle: #24210a;
     --color-auto-blue-2: rgba(/*[[base-color-rgb]]*/, .25);
     --color-auto-blue-3: rgba(/*[[base-color-rgb]]*/, .5);
     --color-auto-blue-4: /*[[base-color]]*/;


### PR DESCRIPTION
This increases some contrast w/r/t some status elements. The effect is more noticeable with text, but I couldn't figure out how to get Firefox to screenshot that.

Before:
![image](https://user-images.githubusercontent.com/27117322/133906982-0d5860c6-e80f-4948-b433-868676af3ad9.png)

After:
![image](https://user-images.githubusercontent.com/27117322/133906989-35d8b5b4-63a0-4040-9cc7-2d04fde1955f.png)

Screenshots taken from @the-j0k3r's user page.