### PR TITLE
Fix unread notification color

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -855,7 +855,7 @@
   }
   /* unread notifications are darker bg than read issue #1095 */
   .blame-hunk .blame-commit, .notifications-list-item.notification-unread {
-    background: #181818;
+    background: #181818 !important;
   }
   /* read notifications are lighter bg than read issue #1095 */
   .notifications-list .list-style-none.bg-gray {


### PR DESCRIPTION
I've had this issue for a while now, but haven't seen anyone else mention it. For me the unread notifications right now are unreadable, so I thought I'd just send a PR.

Before:
![before](https://user-images.githubusercontent.com/8886672/135202618-8cd0fd04-4f26-4c4c-934d-57d91301a6e8.png)

After:
![after](https://user-images.githubusercontent.com/8886672/135202628-b4f2f35f-f7e9-4372-8334-69b1b4766ef7.png)
