### PR TITLE
feat(theme): GitHub Material Theme

### DIFF
--- a/src/themes/github/material.css
+++ b/src/themes/github/material.css
@@ -1,0 +1,100 @@
+/*! GitHub: Material */
+:root {
+  --ghd-code-background: #263238;
+  --ghd-code-color: #ccc;
+}
+.pl-c, .pl-c span { color: #546e7a !important; font-style: italic !important; } /* comment */
+.pl-c1 { color: #c792ea !important; } /* constant */
+.pl-cce { color: #c792ea !important; } /* constant.character.escape */
+.pl-cn { color: #c792ea !important; } /* constant.numeric */
+.pl-coc { color: #c792ea !important; } /* constant.other.color */
+.pl-cos { color: #89ddff !important; } /* constant.other.symbol */
+.pl-e { color: #82aaff !important; } /* entity */
+.pl-ef { color: #82aaff !important; } /* entity.function */
+.pl-en { color: #82aaff !important; } /* entity.name */
+.pl-enc { color: #c792ea !important; } /* entity.name.class */
+.pl-enf { color: #82aaff !important; } /* entity.name.function */
+.pl-enm { color: #82aaff !important; } /* entity.name.method-name */
+.pl-ens { color: #c792ea !important; } /* entity.name.section */
+.pl-ent { color: #cda869 !important; } /* entity.name.tag */
+.pl-entc { color: #82aaff !important; } /* entity.name.type.class */
+.pl-enti { color: #82aaff !important; } /* entity.name.type.instance */
+.pl-entm { color: #7587a6 !important; } /* entity.name.type.module */
+.pl-eoa { color: #cda869 !important; } /* entity.other.attribute-name */
+.pl-eoac { color: #7587a6 !important; } /* entity.other.attribute-name.class */
+.pl-eoac .pl-pde { color: #7587a6 !important; } /* punctuation.definition.entity */
+.pl-eoai { color: #cda869 !important; } /* entity.other.attribute-name.id */
+.pl-eoai .pl-pde { color: #cda869 !important; } /* punctuation.definition.entity */
+.pl-eoi { color: #82aaff !important; } /* entity.other.inherited-class */
+.pl-k { color: #89ddff !important; } /* keyword */
+.pl-ko { color: #cda869 !important; } /* keyword.operator */
+.pl-kolp { color: #cda869 !important; } /* keyword.operator.logical.python */
+.pl-kos { color: #c792ea !important; } /* keyword.other.special-method */
+.pl-kou { color: #c792ea !important; } /* keyword.other.unit */
+.pl-mai .pl-sf { color: #7587a6 !important; } /* support.function */
+.pl-mb { color: #89ddff !important; } /* markup.bold */
+.pl-mc { color: #cda869 !important; } /* markup.changed */
+.pl-mh { color: #c792ea !important; } /* markup.heading */
+.pl-mh .pl-pdh { color: #c792ea !important; } /* markup.heading punctuation.definition.heading */
+.pl-mi { color: #cda869 !important; } /* markup.italic */
+.pl-ml { color: #89ddff !important; } /* markup.list */
+.pl-mm { color: #7587a6 !important; } /* meta.module-reference */
+.pl-mp { color: #c5af75 !important; } /* meta.property-name */
+.pl-mp1 .pl-sf { color: #dad085 !important; } /* meta.property-value support.function */
+.pl-mq { color: #c792ea !important; } /* markup.quote */
+.pl-mr { color: #cda869 !important; } /* meta.require */
+.pl-ms { color: #cda869 !important; } /* meta.selector */
+.pl-pdb { color: #89ddff !important; } /* punctuation.definition.bold */
+.pl-pdc { color: #546e7a !important; } /* punctuation.definition.comment */
+.pl-pdc1 { color: #c792ea !important; } /* punctuation.definition.constant */
+.pl-pde { color: #c792ea !important; } /* punctuation.definition.entity */
+.pl-pdi { color: #cda869 !important; } /* punctuation.definition.italic */
+.pl-pds { color: #89ddff !important; } /* punctuation.definition.string */
+.pl-pdv { color: #7587a6 !important; } /* punctuation.definition.variable */
+.pl-pse { color: #c792ea !important; } /* punctuation.section.embedded */
+.pl-pse .pl-s2 { color: #c792ea !important; } /* punctuation.section.embedded source */
+.pl-s { color: #c3e88d !important; } /* storage */
+.pl-s1 { color: #ccc !important; } /* string */
+.pl-s2 { color: #ccc !important; } /* source */
+.pl-mp .pl-s3 { color: #cda869 !important; } /* support */
+.pl-s3 { color: #dad085 !important; } /* support */
+.pl-sc { color: #dad085 !important; } /* support.class */
+.pl-scp { color: #c792ea !important; } /* support.constant.property-value */
+.pl-sf { color: #dad085 !important; } /* support.function */
+.pl-smc { color: #82aaff !important; } /* storage.modifier.c */
+.pl-smi { color: #ccc !important; } /* storage.modifier.import */
+.pl-smp { color: #ccc !important; } /* storage.modifier.package */
+.pl-sok { color: #cda869 !important; } /* support.other.keyword */
+.pl-sol { color: #89ddff !important; } /* string.other.link */
+.pl-som { color: #7587a6 !important; } /* support.other.module */
+.pl-sr { color: #7587a6 !important; } /* string.regexp */
+.pl-sra { color: #cda869 !important; } /* string.regexp string.regexp.arbitrary-repetition */
+.pl-src { color: #cda869 !important; } /* string.regexp.character-class */
+.pl-sre { color: #cda869 !important; } /* string.regexp source.ruby.embedded */
+.pl-st { color: #cda869 !important; } /* support.type */
+.pl-stj { color: #7587a6 !important; } /* storage.type.java */
+.pl-stp { color: #ffcb6b !important; } /* support.type.property-name */
+.pl-sv { color: #ffcb6b !important; } /* support.variable */
+.pl-v { color: #ffcb6b !important; } /* variable */
+.pl-vi { color: #c792ea !important; } /* variable.interpolation */
+.pl-vo { color: #82aaff !important; } /* variable.other */
+.pl-vpf { color: #7587a6 !important; } /* variable.parameter.function */
+/* diff - example: https://gist.github.com/silverwind/904159f1e71e2e626375 */
+.pl-mi1 { color: #c3e88d !important; background: #020 !important; } /* markup.inserted */
+.pl-mdht { color: #c3e88d !important; background: #020 !important; } /* meta.diff.header.to-file */
+.pl-md { color: #f07178 !important; background: #200 !important; } /* markup.deleted */
+.pl-mdhf { color: #f07178 !important; background: #200 !important; } /* meta.diff.header.from-file */
+.pl-mdr { color: #c792ea !important; } /* meta.diff.range */
+.pl-mdh { color: #7587a6 !important; } /* meta.diff.header */
+.pl-mdi { color: #7587a6 !important; } /* meta.diff.index */
+/* todo: fix unstyled classes below */
+.pl-bu, /* invalid.broken, invalid.deprecated, invalid.unimplemented, message.error, brackethighlighter.unmatched, sublimelinter.mark.error */
+.pl-ii, .pl-ii .pl-cce { background-color: #df5000 !important; color: #fff !important; } /* invalid.illegal */
+.pl-mo { color: #969896 !important; } /* meta.output */
+.pl-mri { color: #008080 !important; } /* markup.raw.inline */
+.pl-ms1 { background-color: #f5f5f5 !important; } /* meta.separator */
+.pl-va { color: #008080 !important; } /* variable.assignment */
+.pl-vpu { color: #008080 !important; } /* variable.parameter.url */
+.pl-entl { color: #ccc !important; } /* entity.name.tag.label */
+.pl-corl, .highlight .pl-corl span.x { color: #c3e88d !important; text-decoration: underline !important; } /* links */
+.pl-token.active, .pl-token:hover { background: #916b53 !important; color: #ffcb6b !important; }

--- a/src/themes/github/material.css
+++ b/src/themes/github/material.css
@@ -4,7 +4,7 @@
   --ghd-code-color: #ccc;
 }
 .pl-c, .pl-c span { color: #546e7a !important; font-style: italic !important; } /* comment */
-.pl-c1 { color: #c792ea !important; } /* constant */
+.pl-c1 { color: #f77669 !important; } /* constant */
 .pl-cce { color: #c792ea !important; } /* constant.character.escape */
 .pl-cn { color: #c792ea !important; } /* constant.numeric */
 .pl-coc { color: #c792ea !important; } /* constant.other.color */
@@ -16,39 +16,39 @@
 .pl-enf { color: #82aaff !important; } /* entity.name.function */
 .pl-enm { color: #82aaff !important; } /* entity.name.method-name */
 .pl-ens { color: #c792ea !important; } /* entity.name.section */
-.pl-ent { color: #cda869 !important; } /* entity.name.tag */
+.pl-ent { color: #f77669 !important; } /* entity.name.tag */
 .pl-entc { color: #82aaff !important; } /* entity.name.type.class */
 .pl-enti { color: #82aaff !important; } /* entity.name.type.instance */
 .pl-entm { color: #7587a6 !important; } /* entity.name.type.module */
-.pl-eoa { color: #cda869 !important; } /* entity.other.attribute-name */
+.pl-eoa { color: #f77669 !important; } /* entity.other.attribute-name */
 .pl-eoac { color: #7587a6 !important; } /* entity.other.attribute-name.class */
 .pl-eoac .pl-pde { color: #7587a6 !important; } /* punctuation.definition.entity */
-.pl-eoai { color: #cda869 !important; } /* entity.other.attribute-name.id */
-.pl-eoai .pl-pde { color: #cda869 !important; } /* punctuation.definition.entity */
+.pl-eoai { color: #f77669 !important; } /* entity.other.attribute-name.id */
+.pl-eoai .pl-pde { color: #f77669 !important; } /* punctuation.definition.entity */
 .pl-eoi { color: #82aaff !important; } /* entity.other.inherited-class */
 .pl-k { color: #89ddff !important; } /* keyword */
-.pl-ko { color: #cda869 !important; } /* keyword.operator */
-.pl-kolp { color: #cda869 !important; } /* keyword.operator.logical.python */
+.pl-ko { color: #f77669 !important; } /* keyword.operator */
+.pl-kolp { color: #f77669 !important; } /* keyword.operator.logical.python */
 .pl-kos { color: #c792ea !important; } /* keyword.other.special-method */
 .pl-kou { color: #c792ea !important; } /* keyword.other.unit */
 .pl-mai .pl-sf { color: #7587a6 !important; } /* support.function */
 .pl-mb { color: #89ddff !important; } /* markup.bold */
-.pl-mc { color: #cda869 !important; } /* markup.changed */
+.pl-mc { color: #f77669 !important; } /* markup.changed */
 .pl-mh { color: #c792ea !important; } /* markup.heading */
 .pl-mh .pl-pdh { color: #c792ea !important; } /* markup.heading punctuation.definition.heading */
-.pl-mi { color: #cda869 !important; } /* markup.italic */
+.pl-mi { color: #f77669 !important; } /* markup.italic */
 .pl-ml { color: #89ddff !important; } /* markup.list */
 .pl-mm { color: #7587a6 !important; } /* meta.module-reference */
 .pl-mp { color: #c5af75 !important; } /* meta.property-name */
 .pl-mp1 .pl-sf { color: #dad085 !important; } /* meta.property-value support.function */
 .pl-mq { color: #c792ea !important; } /* markup.quote */
-.pl-mr { color: #cda869 !important; } /* meta.require */
-.pl-ms { color: #cda869 !important; } /* meta.selector */
+.pl-mr { color: #f77669 !important; } /* meta.require */
+.pl-ms { color: #f77669 !important; } /* meta.selector */
 .pl-pdb { color: #89ddff !important; } /* punctuation.definition.bold */
 .pl-pdc { color: #546e7a !important; } /* punctuation.definition.comment */
 .pl-pdc1 { color: #c792ea !important; } /* punctuation.definition.constant */
 .pl-pde { color: #c792ea !important; } /* punctuation.definition.entity */
-.pl-pdi { color: #cda869 !important; } /* punctuation.definition.italic */
+.pl-pdi { color: #f77669 !important; } /* punctuation.definition.italic */
 .pl-pds { color: #89ddff !important; } /* punctuation.definition.string */
 .pl-pdv { color: #7587a6 !important; } /* punctuation.definition.variable */
 .pl-pse { color: #c792ea !important; } /* punctuation.section.embedded */
@@ -56,7 +56,7 @@
 .pl-s { color: #c3e88d !important; } /* storage */
 .pl-s1 { color: #ccc !important; } /* string */
 .pl-s2 { color: #ccc !important; } /* source */
-.pl-mp .pl-s3 { color: #cda869 !important; } /* support */
+.pl-mp .pl-s3 { color: #f77669 !important; } /* support */
 .pl-s3 { color: #dad085 !important; } /* support */
 .pl-sc { color: #dad085 !important; } /* support.class */
 .pl-scp { color: #c792ea !important; } /* support.constant.property-value */
@@ -64,14 +64,14 @@
 .pl-smc { color: #82aaff !important; } /* storage.modifier.c */
 .pl-smi { color: #ccc !important; } /* storage.modifier.import */
 .pl-smp { color: #ccc !important; } /* storage.modifier.package */
-.pl-sok { color: #cda869 !important; } /* support.other.keyword */
+.pl-sok { color: #f77669 !important; } /* support.other.keyword */
 .pl-sol { color: #89ddff !important; } /* string.other.link */
 .pl-som { color: #7587a6 !important; } /* support.other.module */
 .pl-sr { color: #7587a6 !important; } /* string.regexp */
-.pl-sra { color: #cda869 !important; } /* string.regexp string.regexp.arbitrary-repetition */
-.pl-src { color: #cda869 !important; } /* string.regexp.character-class */
-.pl-sre { color: #cda869 !important; } /* string.regexp source.ruby.embedded */
-.pl-st { color: #cda869 !important; } /* support.type */
+.pl-sra { color: #f77669 !important; } /* string.regexp string.regexp.arbitrary-repetition */
+.pl-src { color: #f77669 !important; } /* string.regexp.character-class */
+.pl-sre { color: #f77669 !important; } /* string.regexp source.ruby.embedded */
+.pl-st { color: #f77669 !important; } /* support.type */
 .pl-stj { color: #7587a6 !important; } /* storage.type.java */
 .pl-stp { color: #ffcb6b !important; } /* support.type.property-name */
 .pl-sv { color: #ffcb6b !important; } /* support.variable */
@@ -89,7 +89,7 @@
 .pl-mdi { color: #7587a6 !important; } /* meta.diff.index */
 /* todo: fix unstyled classes below */
 .pl-bu, /* invalid.broken, invalid.deprecated, invalid.unimplemented, message.error, brackethighlighter.unmatched, sublimelinter.mark.error */
-.pl-ii, .pl-ii .pl-cce { background-color: #df5000 !important; color: #fff !important; } /* invalid.illegal */
+.pl-ii, .pl-ii .pl-cce { background-color: #f07178 !important; color: #fff !important; } /* invalid.illegal */
 .pl-mo { color: #969896 !important; } /* meta.output */
 .pl-mri { color: #008080 !important; } /* markup.raw.inline */
 .pl-ms1 { background-color: #f5f5f5 !important; } /* meta.separator */


### PR DESCRIPTION
**Note**: This is not exactly a continuation of https://github.com/StylishThemes/GitHub-Dark/pull/568.

I just mostly used coloring rules from the Twilight Theme which looks the most consistent and replaced the colors with Material colors from [here](https://github.com/material-theme/vsc-material-theme/blob/7850c56ad75ab690524b7ecbe4f853c8b68e42e9/scripts/generator/settings/specific/default.ts).

So this is essentially Twilight Theme (in terms of color rules) but with Material colors. Please let me know if you prefer it to be a continuation of https://github.com/StylishThemes/GitHub-Dark/pull/568 instead, I can close this if that is the case.