### PR TITLE
Fixed line height in GitHub Custom Fonts

### DIFF
--- a/github-custom-fonts.user.css
+++ b/github-custom-fonts.user.css
@@ -13,9 +13,10 @@
 ==/UserStyle== */
 @-moz-document regexp("^https?://((education|gist|graphql|guides|raw|resources|status|developer|support|vscode-auth)\\.)?github\\.com/((?!generated_pages/preview).)*$"), regexp("^https?://www\.zuora\.com.*github\.com.*"), domain("githubusercontent.com"), domain("www.githubstatus.com"), domain("stylishthemes.github.io") {
   pre, code, tt, kbd:not(.badmono), samp, .blob-code, .file-data pre, .line-data,
-  #gist-form .file .input textarea, .blob-code-inner {
+  #gist-form .file .input textarea, .blob-code-inner, .blob-num {
     font-family: var(--ghd-font-family), Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
     font-feature-settings: var(--ghd-font-feature-settings) !important;
     font-size: var(--ghd-font-size) !important;
+    line-height: 1.6 !important;
   }
 }


### PR DESCRIPTION
Line numbers were not styled, and the line height was fixed on 20px in the default GitHub style sheets.