### PR TITLE
Start to VS Code Dark Theme (Github)

### DIFF
--- a/src/themes/github/vs-code-dark.css
+++ b/src/themes/github/vs-code-dark.css
@@ -1,0 +1,102 @@
+/*! GitHub: VS Code Dark */
+:root {
+    --ghd-code-background: #1E1E1E;
+    --ghd-code-color: #C8C8C8;
+  }
+  .pl-c, .pl-c span { color: #6A9955 !important; } /* comment */
+  .pl-c1 { color: #D4D4D4 !important; } /* constant */
+  .pl-cce { color: #D7BA7D !important; } /* constant.character.escape */
+  .pl-cn { color: #B5CEA8 !important; } /* constant.numeric */
+  .pl-coc { color: #CE9178 !important; } /* constant.other.color */
+  .pl-cos { color: #C8C8C8 !important; } /* constant.other.symbol */
+  .pl-e { color: #C8C8C8 !important; } /* entity */
+  .pl-ef { color: #C8C8C8 !important; } /* entity.function */
+  .pl-en { color: #DCDCAA !important; } /* entity.name */
+  .pl-enc { color: #DCDCAA !important; } /* entity.name.class */
+  .pl-enf { color: #C8C8C8 !important; } /* entity.name.function */
+  .pl-enm { color: #C8C8C8 !important; } /* entity.name.method-name */
+  .pl-ens { color: #C8C8C8 !important; } /* entity.name.section */
+  .pl-ent { color: #569CD6 !important; } /* entity.name.tag */
+  .pl-entc { color: #4EC9B0 !important; } /* entity.name.type.class */
+  .pl-enti { color: #4EC9B0 !important; } /* entity.name.type.instance */
+  .pl-entm { color: #4EC9B0 !important; } /* entity.name.type.module */
+  .pl-eoa { color: #C8C8C8 !important; } /* entity.other.attribute-name */
+  .pl-eoac { color: #D7BA7D !important; } /* entity.other.attribute-name.class */
+  .pl-eoac .pl-pde { color: #C8C8C8 !important; } /* punctuation.definition.entity */
+  .pl-eoai { color: #D7BA7D !important; } /* entity.other.attribute-name.id */
+  .pl-eoai { color: #5DAFED !important; } /* punctuation.definition.entity */
+  .pl-pde { color: #5DAFED !important; } /* punctuation.definition.entity */
+  .pl-eoi { color: #4EC9B0 !important; } /* entity.other.inherited-class */
+  .pl-k { color: #569CD6 !important; } /* keyword */
+  .pl-ko { color: #C8C8C8 !important; } /* keyword.operator */
+  .pl-kolp { color: #569CD6 !important; } /* keyword.operator.logical.python */
+  .pl-kos { color: #808080 !important; } /* keyword.other.special-method */
+  .pl-kou { color: #B5CEA8 !important; } /* keyword.other.unit */
+  .pl-mai .pl-sf { color: #DCDCAA !important; } /* support.function */
+  .pl-mb { color: #569CD6 !important; } /* markup.bold */
+  .pl-mc { color: #569CD6 !important; } /* markup.changed */
+  .pl-mh { color: #569CD6 ; font-weight: bold !important; } /* markup.heading */
+  .pl-mh .pl-pdh { color: #569CD6; font-weight: bold !important; } /* markup.heading punctuation.definition.heading */
+  .pl-mi { font-style: italic !important; } /* markup.italic */
+  .pl-ml { color: #C8C8C8 !important; } /* markup.list */
+  .pl-mm { color: #C8C8C8  !important; } /* meta.module-reference */
+  .pl-mp { color: #C8C8C8  !important; } /* meta.property-name */
+  .pl-mp1 .pl-sf { color: #C8C8C8  !important; } /* meta.property-value support.function */
+  .pl-mq { color: #C8C8C8  !important; } /* markup.quote */
+  .pl-mr { color: #C8C8C8  !important; } /* meta.require */
+  .pl-ms { color: #C8C8C8  !important; } /* meta.selector */
+  .pl-pdb { color: #C8C8C8 !important; } /* punctuation.definition.bold */
+  .pl-pdc { color: #C8C8C8 !important; } /* punctuation.definition.comment */
+  .pl-pdc1 { color: #C8C8C8  !important; } /* punctuation.definition.constant */
+  .pl-pde { color: #C8C8C8  !important; } /* punctuation.definition.entity */
+  .pl-pdi { color: #C8C8C8  !important; } /* punctuation.definition.italic */
+  .pl-pds { color: #CE9178 !important; } /* punctuation.definition.string */
+  .pl-pdv { color: #7587a6 !important; } /* punctuation.definition.variable */
+  .pl-pse { color: #569CD6 !important; } /* punctuation.section.embedded */
+  .pl-pse .pl-s2 { color: #C8C8C8 !important; } /* punctuation.section.embedded source */
+  .pl-s { color: #CE9178 !important; } /* storage */
+  .pl-s1 { color: #9CDCFE !important; } /* string */
+  .pl-s2 { color: #C8C8C8 !important; } /* source */
+  .pl-mp .pl-s3 { color: #C8C8C8 !important; } /* support */
+  .pl-s3 { color: #C8C8C8 !important; } /* support */
+  .pl-sc { color: #4EC9B0  !important; } /* support.class */
+  .pl-scp { color: #CE9178 !important; } /* support.constant.property-value */
+  .pl-sf { color: #DCDCAA !important; } /* support.function */
+  .pl-smc { color: #569CD6!important; } /* storage.modifier.c */
+  .pl-smi { color: #4EC9B0 !important; } /* storage.modifier.import */
+  .pl-smp { color: #C8C8C8 !important; } /* storage.modifier.package */
+  .pl-sok { color: #C8C8C8 !important; } /* support.other.keyword */
+  .pl-sol { color: #C8C8C8 !important; } /* string.other.link */
+  .pl-som { color: #C8C8C8 !important; } /* support.other.module */
+  .pl-sr { color: #D16969 !important; } /* string.regexp */
+  .pl-sra { color: #D16969 !important; } /* string.regexp string.regexp.arbitrary-repetition */
+  .pl-src { color: #D16969 !important; } /* string.regexp.character-class */
+  .pl-sre { color: #D16969 !important; } /* string.regexp source.ruby.embedded */
+  .pl-st { color: #C8C8C8 !important; } /* support.type */
+  .pl-stj { color: #C8C8C8 !important; } /* storage.type.java */
+  .pl-stp { color: #9CDCFE !important; } /* support.type.property-name */
+  .pl-sv { color: #9CDCFE !important; } /* support.variable */
+  .pl-v { color: #4EC9B0 !important; } /* variable */
+  .pl-vi { color: #9CDCFE !important; } /* variable.interpolation */
+  .pl-vo { color: #C8C8C8 !important; } /* variable.other */
+  .pl-vpf { color: #C8C8C8 !important; } /* variable.parameter.function */
+  /* diff - example: https://gist.github.com/silverwind/904159f1e71e2e626375 */
+  .pl-mi1 { color: #B5CEA8 !important; background: #141414 !important; } /* markup.inserted */
+  .pl-mdht { color: #B5CEA8 !important; background: #141414 !important;  } /* meta.diff.header.to-file */
+  .pl-md { color: #CE9178 !important; background: #141414 !important; } /* markup.deleted */
+  .pl-mdhf { color: #CE9178 !important; background: #141414 !important; } /* meta.diff.header.from-file */
+  .pl-mdr { color: #BDBAD9 !important; } /* meta.diff.range */
+  .pl-mdh { color: #569CD6 !important; } /* meta.diff.header */
+  .pl-mdi { color: #C8C8C8 !important; } /* meta.diff.index */
+  /* todo: fix unstyled classes below */
+  .pl-bu, /* invalid.broken, invalid.deprecated, invalid.unimplemented, message.error, brackethighlighter.unmatched, sublimelinter.mark.error */
+  .pl-ii, .pl-ii .pl-cce { background-color: #df5000 !important; color: #fff !important; } /* invalid.illegal */
+  .pl-mo { color: #969896 !important; } /* meta.output */
+  .pl-mri { color: #CE9178 !important; } /* markup.raw.inline */
+  .pl-ms1 { background-color: #606060 !important; } /* meta.separator */
+  .pl-va { color: #C8C8C8 !important; } /* variable.assignment */
+  .pl-vpu { color: #C8C8C8 !important; } /* variable.parameter.url */
+  .pl-entl { color: #C8C8C8 !important; } /* entity.name.tag.label */
+  .pl-corl, .highlight .pl-corl span.x { color: #3794ff !important; text-decoration: underline !important; } /* links */
+  .pl-token.active, .pl-token:hover { background: #202A34 !important; }
+  


### PR DESCRIPTION
This is my attempt at replicating Visual Studio Code's default "Dark+" theme. 

![image](https://user-images.githubusercontent.com/68123410/181415248-63c1ce3a-b75c-46ad-a2e0-eaa94baedf78.png)

Similar to [#1334](https://github.com/StylishThemes/GitHub-Dark/pull/1334), I used the Twlight theme as a template and substituted colors from VS Code's `.json` schema ([`dark_plus`](https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_plus.json) and [`dark_vs`](https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_vs.json)).

Note that the comments in `vs-code-dark.css` were copied verbatim from `twilight.css`. I didn't attempt to document any sort of precise mapping between GitHub-Dark's color-matching rules and VS Code's grammar scopes.




