### PR TITLE
[Issue #1348] Support New Code Search and Code View feature preview

### DIFF
--- a/github-custom-fonts.user.css
+++ b/github-custom-fonts.user.css
@@ -13,7 +13,7 @@
 ==/UserStyle== */
 @-moz-document regexp("^https?://((education|gist|graphql|guides|raw|resources|status|developer|support|vscode-auth)\\.)?github\\.com/((?!generated_pages/preview).)*$"), regexp("^https?://www\.zuora\.com.*github\.com.*"), domain("githubusercontent.com"), domain("www.githubstatus.com"), domain("stylishthemes.github.io") {
   pre, code, tt, kbd:not(.badmono), samp, .blob-code, .file-data pre, .line-data,
-  #gist-form .file .input textarea, .blob-code-inner {
+  #gist-form .file .input textarea, .blob-code-inner, .react-code-text {
     font-family: var(--ghd-font-family), Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
     font-feature-settings: var(--ghd-font-feature-settings) !important;
     font-size: var(--ghd-font-size) !important;

--- a/github-custom-fonts.user.css
+++ b/github-custom-fonts.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name         GitHub Custom Fonts
 @namespace    StylishThemes
-@version      5.2.13
+@version      5.2.14
 @homepageURL  https://github.com/StylishThemes/GitHub-Dark
 @updateURL    https://stylishthemes.github.io/GitHub-Dark/github-custom-fonts.user.css
 @license      BSD-2-Clause

--- a/github-custom-fonts.user.css
+++ b/github-custom-fonts.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name         GitHub Custom Fonts
 @namespace    StylishThemes
-@version      5.2.14
+@version      5.2.13
 @homepageURL  https://github.com/StylishThemes/GitHub-Dark
 @updateURL    https://stylishthemes.github.io/GitHub-Dark/github-custom-fonts.user.css
 @license      BSD-2-Clause

--- a/github-custom-fonts.user.css
+++ b/github-custom-fonts.user.css
@@ -13,7 +13,7 @@
 ==/UserStyle== */
 @-moz-document regexp("^https?://((education|gist|graphql|guides|raw|resources|status|developer|support|vscode-auth)\\.)?github\\.com/((?!generated_pages/preview).)*$"), regexp("^https?://www\.zuora\.com.*github\.com.*"), domain("githubusercontent.com"), domain("www.githubstatus.com"), domain("stylishthemes.github.io") {
   pre, code, tt, kbd:not(.badmono), samp, .blob-code, .file-data pre, .line-data,
-  #gist-form .file .input textarea, .blob-code-inner, .react-code-text {
+  #gist-form .file .input textarea, .blob-code-inner, .react-code-text, .jujkut {
     font-family: var(--ghd-font-family), Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
     font-feature-settings: var(--ghd-font-feature-settings) !important;
     font-size: var(--ghd-font-size) !important;


### PR DESCRIPTION
- Added initial support for [New Code Search and Code View feature preview](https://docs.github.com/en/repositories/working-with-files/managing-files/navigating-files-with-the-new-code-view):
  * All text on Code pane
  * Symbol name on Symbols pane

![image](https://user-images.githubusercontent.com/5612696/222545853-8f502151-2d74-4fbf-8db5-f65501fa6c3d.png)

Related issue: https://github.com/StylishThemes/GitHub-Dark/issues/1348