### PR TITLE
fix notebook style generation

### DIFF
--- a/src/render.css
+++ b/src/render.css
@@ -5,7 +5,7 @@
     --jp-content-font-color3: #aaa;
     --jp-content-font-color4: #999;
   }
-  /* generated render.githubusercontent.com rules */
+  /* generated notebooks.githubusercontent.com rules */
   body, .render-shell {
     background: var(--ghd-code-background) !important;
   }

--- a/tools/build.js
+++ b/tools/build.js
@@ -111,6 +111,10 @@ async function main() {
         const suffix = `  /* end ${source.name} rules */`;
         section = `${prefix}\n${section}\n${suffix}`;
         const re = new RegExp(`.*generated ${esc(source.name)} rules.*`, "gm");
+        const matches = Array.from(sourceCss.matchAll(re));
+        if (matches.length !== 1) {
+          throw new Error(`Expected one generated ${source.name} rules marker in ${sourceFile}, found ${matches.length}`);
+        }
         sourceCss = sourceCss.replace(re, section);
       }
     }


### PR DESCRIPTION
The notebook CSS source was renamed to `notebooks.githubusercontent.com`, but
`src/render.css` kept the old `render.githubusercontent.com` marker. The build
therefore fetched and remapped notebook styles, then silently skipped their
insertion because the generated-section marker never matched.

- Align the marker with the current source name.
- Fail the build unless a generated section has exactly one marker.

Checks:
- `make test`
- `make build` (one notebook `begin`/`end` section, 77 generated lines)
